### PR TITLE
Add GitHub Action for automated Fly deployment

### DIFF
--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -1,5 +1,6 @@
 name: Deploy to Fly
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -1,5 +1,6 @@
-name: Deploy to Fly
+name: Deploy Nuxt Application to Fly.io
 on:
+  # Allows the workflow to be manually triggered from the GitHub Actions UI
   workflow_dispatch:
   pull_request:
     branches:
@@ -8,19 +9,22 @@ on:
       - closed
   push:
     branches:
+      # Branches for multiple posts
       - 'posts/*'
+      # Branches for single post
       - 'post/*'
       - 'feature/*'
-      - 'wip/*'
 jobs:
   deploy:
-    name: Deploy proxy
+    name: Deploy to Fly.io
     runs-on: ubuntu-latest
     steps:
       # This step checks out a copy of your repository.
       - uses: actions/checkout@v2
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions@1.5
         with:
+          # Using version v0.3.14 of flyctl based on recommendation to pin the version
+          # in the docs https://fly.io/docs/launch/continuous-deployment-with-github-actions/
           version: v0.3.14
       - run: flyctl deploy --remote-only
         env:

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -1,0 +1,27 @@
+name: Deploy to Fly
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+  push:
+    branches-ignore:
+      - main
+    branches:
+      - 'posts/*'
+      - 'feature/*'
+      - 'wip/*'
+jobs:
+  deploy:
+    name: Deploy proxy
+    runs-on: ubuntu-latest
+    steps:
+      # This step checks out a copy of your repository.
+      - uses: actions/checkout@v2
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+        with:
+          version: v0.3.14
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -6,10 +6,9 @@ on:
     types:
       - closed
   push:
-    branches-ignore:
-      - main
     branches:
       - 'posts/*'
+      - 'post/*'
       - 'feature/*'
       - 'wip/*'
 jobs:


### PR DESCRIPTION
This pull request introduces a GitHub Action for deploying Nuxt applications to Fly.io, triggered by closed pull requests to the main branch and pushes to specific branches (`posts/*`, `post/*`, and `feature/*`). The workflow now allows for manual triggers, enhancing control over deployments. Additionally, the CI workflow has been updated to include builds on pushes to the main branch and support for single post branches. These enhancements streamline our CI/CD pipeline, improve clarity, and ensure comprehensive coverage for automated testing and integration. The deployment job has been configured to use a specific version of the Fly CLI for better reliability.