### PR TITLE
Fix code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/app/pages/careers.vue
+++ b/app/pages/careers.vue
@@ -81,6 +81,7 @@
 <script setup lang="ts">
 import { Icon } from '@iconify/vue';
 import { ref } from 'vue';
+import he from 'he';
 
 const commitments = ref([
   { title: 'Diversity', description: 'We value the unique perspectives and experiences that each individual brings to our team.', icon: 'lucide:users' },
@@ -128,7 +129,7 @@ function deobfuscateEmails(): void {
     const email = el.textContent?.replace(/ &#65;&#84; /g, "@").replace(/ AT /g, "@").replace(/ D0T /g, ".") || '';
     const subject = el.getAttribute('data-subject');
     const subjectParam = subject ? `?subject=${encodeURIComponent(subject)}` : '';
-    el.innerHTML = `<a class="dark:text-gray-300" href="mailto:${email}${subjectParam}">${email}</a>`;
+    el.innerHTML = `<a class="dark:text-gray-300" href="mailto:${he.encode(email)}${subjectParam}">${he.encode(email)}</a>`;
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "nuxt": "^3.13.2",
     "nuxt-og-image": "3.0.4",
     "nuxt-security": "2.0.0",
-    "shiki": "^1.21.0"
+    "shiki": "^1.21.0",
+    "he": "^1.2.0"
   },
   "devDependencies": {
     "@flydotio/dockerfile": "^0.5.9",


### PR DESCRIPTION
Fixes [https://github.com/onetimesecret/docs.onetimesecret.com/security/code-scanning/1](https://github.com/onetimesecret/docs.onetimesecret.com/security/code-scanning/1)

To fix the problem, we need to ensure that any text content extracted from the DOM and used to construct HTML is properly escaped to prevent XSS attacks. We can use a library like `he` (HTML entities) to encode the text content before inserting it into the HTML string. This will ensure that any special characters are properly escaped and cannot be interpreted as HTML.

1. Install the `he` library to handle HTML entity encoding.
2. Import the `he` library in the script section.
3. Use the `he.encode` function to encode the `email` variable before using it in the HTML string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
