### PR TITLE
Remove explicit remote deployment option in flyctl command

### DIFF
--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -41,7 +41,7 @@ jobs:
 
       # Step 3: Deploy to the Cloud Dimension
       - name: Deploy to the Cloud Dimension
-        run: flyctl deploy --remote-only
+        run: flyctl deploy
         env:
           # The FLY_API_TOKEN should be set as a secret in your GitHub repository
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
This PR removes the `--remote-only` flag from the deploy command in the CI workflow, allowing for local deployment options. This change enhances flexibility in deployment strategies, accommodating environments that require local builds due to specific configurations or dependencies.