### PR TITLE
Fix unexpected input error in Cloud Dimension CLI setup

### DIFF
--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -33,11 +33,11 @@ jobs:
 
       # Step 2: Set up Cloud Dimension CLI
       - name: Set up Cloud Dimension CLI
-        uses: superfly/flyctl-actions@1.5
-        with:
+        uses: superfly/flyctl-actions/setup-flyctl@1.5
+        #with:
           # Using version v0.3.14 of flyctl based on recommendation to pin the version
           # in the docs https://fly.io/docs/launch/continuous-deployment-with-github-actions/
-          version: v0.3.14
+          # version: v0.3.14
 
       # Step 3: Deploy to the Cloud Dimension
       - name: Deploy to the Cloud Dimension


### PR DESCRIPTION
This PR addresses the issue of unexpected input errors related to the 'version' parameter in the Cloud Dimension CLI setup. The action has been updated to use the correct setup method, and the version input has been commented out to align with the valid inputs. This change ensures smoother deployment processes.

https://github.com/marketplace/actions/github-action-for-flyctl