### PR TITLE
Update custom domain hosts

### DIFF
--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -1,5 +1,5 @@
 
-name: Deploy Nuxt Application to the Cloud Realm
+name: Deploy to the Cloud Realm
 
 on:
   # Allows the workflow to be manually triggered from the Grand UI of Actions

--- a/content/1.docs/3.custom-domains/2.setup-guide.md
+++ b/content/1.docs/3.custom-domains/2.setup-guide.md
@@ -49,8 +49,8 @@ To connect your domain, you need to update your DNS settings. The process differ
 2. Create a CNAME record with the following details:
    - Host: Your chosen subdomain (e.g., secrets)
    - Points to / Value:
-     - For EU region: identity-eu.onetime.co
-     - For US region: identity-us.onetime.co
+     - For EU region: identity.eu.onetime.co
+     - For US region: identity.us.onetime.co
 3. Remove any existing A, AAAA, or CNAME records for the same subdomain
 
 ### For Apex Domains
@@ -95,7 +95,7 @@ Apex domains cannot use CNAME records due to DNS standards. Therefore, we must u
 Once setup is complete, you should see the following information:
 
 - Domain Status: Active with SSL
-- Target Address: identity-eu.onetime.co or identity-us.onetime.co (depending on your chosen region)
+- Target Address: identity.eu.onetime.co or identity.us.onetime.co (depending on your chosen region)
 - SSL Status: Active
 - SSL Renewal Date: (Will be displayed, typically about a year from setup)
 

--- a/content/1.docs/3.custom-domains/2.setup-guide.md
+++ b/content/1.docs/3.custom-domains/2.setup-guide.md
@@ -49,8 +49,8 @@ To connect your domain, you need to update your DNS settings. The process differ
 2. Create a CNAME record with the following details:
    - Host: Your chosen subdomain (e.g., secrets)
    - Points to / Value:
-     - For EU region: eu.onetimesecret.com
-     - For US region: us.onetimesecret.com
+     - For EU region: identity-eu.onetime.co
+     - For US region: identity-us.onetime.co
 3. Remove any existing A, AAAA, or CNAME records for the same subdomain
 
 ### For Apex Domains
@@ -95,7 +95,7 @@ Apex domains cannot use CNAME records due to DNS standards. Therefore, we must u
 Once setup is complete, you should see the following information:
 
 - Domain Status: Active with SSL
-- Target Address: eu.onetimesecret.com or us.onetimesecret.com (depending on your chosen region)
+- Target Address: identity-eu.onetime.co or identity-us.onetime.co (depending on your chosen region)
 - SSL Status: Active
 - SSL Renewal Date: (Will be displayed, typically about a year from setup)
 
@@ -108,7 +108,7 @@ Once setup is complete, you should see the following information:
 ## Using Your Custom Domain
 
 Once active, your secret links will use your custom domain. For example:
-`https://secrets.yourdomain.com/secrets/abc123`
+`https://secrets-example.onetime.dev/secret/abc123`
 
 ## We've Got You Covered
 


### PR DESCRIPTION
These updates ensure accurate guidance for users configuring their custom domains with the latest OneTime infrastructure. 

The CNAME records for connecting domains have been updated to use the new identity-eu.onetime.co and identity-us.onetime.co addresses. 

Additionally, the example secret link in the documentation has been updated to use the new secrets-example.onetime.dev domain. This PR provides users with the most up-to-date information for setting up their custom domains.