### PR TITLE
Update .gitignore and fix documentation link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ tmp
 .env
 .env.*
 !.env.example
+.ruby-version
 
 # VSC
 .history
@@ -33,3 +34,7 @@ tmp
 # Docker
 Dockerfile.*
 !Dockerfile.example
+
+# Jupyter
+.ipynb_checkpoints
+*.ipynb

--- a/content/1.docs/3.custom-domains/1.index.md
+++ b/content/1.docs/3.custom-domains/1.index.md
@@ -36,7 +36,7 @@ Custom Domains are particularly valuable for:
 
 1. You register a domain or use one you already own.
 2. Choose your preferred data center region (EU or US).
-3. [Configure your domain's DNS settings](https://docs.onetime.co/docs/custom-domains/setup-guide) to point to Onetime Secret's servers in your chosen region.
+3. [Configure your domain's DNS settings](/docs/custom-domains/setup-guide) to point to Onetime Secret's servers in your chosen region.
 4. Set up the custom domain in your Onetime Secret account settings.
 5. Once verified, your secret links will use your custom domain.
 


### PR DESCRIPTION
Add a new entry to the .gitignore for Ruby version files and update a documentation link to use a relative path.