### PR TITLE
Fix typo in documentation

### DIFF
--- a/content/1.docs/4.rest-api/1.index.md
+++ b/content/1.docs/4.rest-api/1.index.md
@@ -51,7 +51,7 @@ Onetime Secret supports multiple geographic data centers. We follow a zero data 
 - **NOTE:** Currently, access via `onetimesecret.com/api` is still operational but using a specific locality is recommended as this functionality may be deprecated in the future.
 
 ## Custom Domains
-Onetime Secret supports custom domain configurations for organizations with specific networking or branding requirements via out [Identity Plus](https://onetimesecret.com/pricing) plan.
+Onetime Secret supports custom domain configurations for organizations with specific networking or branding requirements via our [Identity Plus](https://onetimesecret.com/pricing) plan.
 
 ### Custom Domain Benefits
 - **Private Branding:** Use your own domain (e.g., `secrets.example.com`) for API access and secret sharing


### PR DESCRIPTION
Corrected a typo in the documentation regarding custom domain configurations.