### PR TITLE
Configure base URL handling for custom domains

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,9 +39,13 @@ jobs:
       - run: pnpm install
 
       # Set base URL for GitHub Pages
-      - name: Set base URL
+      - name: Set base URL for custom domain
         run: |
-          echo "VITE_BASE_URL=/" >> .env.production
+          if [ -f "./public/CNAME" ] || [ -f "./static/CNAME" ]; then
+            echo "VITE_BASE_URL=/" >> .env.production
+          else
+            echo "VITE_BASE_URL=/starlight/" >> .env.production
+          fi
 
       - name: Build
         run: pnpm run build

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,7 @@ import { createViteConfig } from "./config/vite";
 
 export default defineConfig({
   site: "https://docs.onetimesecret.com",
+  base: process.env.VITE_BASE_URL || "/",
   integrations: createIntegrations(),
   vite: createViteConfig(),
 });

--- a/config/vite.ts
+++ b/config/vite.ts
@@ -2,7 +2,7 @@ export function createViteConfig() {
   // Remember, for security reasons, only variables prefixed with VITE_ are
   // available here to prevent accidental exposure of sensitive
   // environment variables to the client-side code.
-  const viteBaseUrl = process.env.VITE_BASE_URL;
+  const viteBaseUrl = process.env.VITE_BASE_URL || "/";
 
   // According to the documentation, we should be able to set the allowed hosts
   // via __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS but as of 5.4.15m that is not
@@ -19,6 +19,7 @@ export function createViteConfig() {
     process.env.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS;
 
   return {
+    base: viteBaseUrl,
     server: {
       origin: viteBaseUrl,
       allowedHosts: (() => {


### PR DESCRIPTION
Detects custom domains via CNAME files. Uses root path for custom domains and /starlight/ path for GitHub Pages deployments.