### PR TITLE
Add theme customization with brand colors

### DIFF
--- a/config/starlight.mjs
+++ b/config/starlight.mjs
@@ -32,7 +32,11 @@ export const starlightConfig = {
     blueSky: "https://bskyapp/profile/onetimesecretcom",
     github: "https://github.com/onetimesecret/onetimesecret",
   },
-  customCss: ["./src/styles/tailwind.css", "./src/fonts/font-face.css"],
+  customCss: [
+    "./src/styles/tailwind.css",
+    "./src/fonts/font-face.css",
+    "./src/styles/theme-overrides.css",
+  ],
   defaultLocale: i18nConfig.defaultLocale,
   locales: i18nConfig.locales,
   sidebar,

--- a/src/content/i18n/en.json
+++ b/src/content/i18n/en.json
@@ -2,7 +2,7 @@
   "nav": {
     "label": {
       "blog": "Blog",
-      "custom-domain": "Custom Domain",
+      "custom-domain": "Custom Domains",
       "principles": "Principles",
       "rest-api": "API",
       "home": "Back to onetimesecret.com"

--- a/src/styles/theme-overrides.css
+++ b/src/styles/theme-overrides.css
@@ -1,0 +1,37 @@
+/* src/styles/theme-overrides.css */
+
+/* Set ALL possible Starlight accent-related CSS custom properties */
+:root {
+  /* Core accent variables */
+  --sl-color-accent-low: #fcf4e8;
+  --sl-color-accent: #dc4a22;
+  --sl-color-accent-high: #a32d12;
+
+  /* Text accent variable - this is what the button is actually using */
+  --sl-color-text-accent: #dc4a22 !important;
+}
+
+:root[data-theme="dark"] {
+  --sl-color-accent-low: #85200c;
+  --sl-color-accent: #dc4a22;
+  --sl-color-accent-high: #f0c39e;
+  --sl-color-text-accent: #dc4a22 !important;
+}
+
+/* Target the exact selector from your build */
+.sl-link-button:where(.astro-w4zgqqgl).primary {
+  background: var(--sl-color-text-accent) !important;
+  border-color: var(--sl-color-text-accent) !important;
+  color: var(--sl-color-black) !important;
+}
+
+.sl-link-button:where(.astro-w4zgqqgl).primary:hover {
+  background: #a32d12 !important;
+  border-color: #a32d12 !important;
+}
+
+/* Additional fallback for any button that might use different classes */
+.sl-link-button.primary {
+  background: #dc4a22 !important;
+  border-color: #dc4a22 !important;
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -84,5 +84,12 @@ export default {
     },
   },
 
-  plugins: [starlightPlugin()],
+  plugins: [
+    starlightPlugin({
+      theme: {
+        accent: brandColour[500], // Your main red (#dc4a22)
+        accentDark: brandColour[600], // Darker shade for dark mode
+      },
+    }),
+  ],
 };


### PR DESCRIPTION
Apply brand color (#dc4a22) to Starlight theme through CSS overrides and plugin configuration. Focus on button styling and accent colors for both light and dark modes. Also pluralize "Custom Domain" to "Custom Domains" in navigation.