### PR TITLE
Add redirect for REST API

### DIFF
--- a/config/redirects.mjs
+++ b/config/redirects.mjs
@@ -12,6 +12,8 @@
 export function createRedirectsConfig() {
   return {
     "/api": "/en/rest-api/",
+    "/rest-api": "/en/rest-api/",
+    "/docs/rest-api": "/en/rest-api/",
     "/blog": "https://blog.onetimesecret.com/",
     "/contact": "https://onetimesecret.com/feedback",
     "/docs": "/en/",


### PR DESCRIPTION
Currently the footer link on the sites is going to still going to /docs/rest-api