### PR TITLE
Add missing homepage content files for four languages

### DIFF
--- a/src/content/docs/da/index.mdoc
+++ b/src/content/docs/da/index.mdoc
@@ -1,0 +1,80 @@
+---
+title: Onetime Secret - Sikre links, stærkere forbindelser
+description: Onetime Secret tilbyder en sikker, midlertidig måde at dele følsom information i en digital verden.
+tableOfContents:
+  minHeadingLevel: 3
+hero:
+  title: Sikre links, stærkere forbindelser
+  tagline: Del følsom information sikkert med selvdestruerende links, der kun kan ses én gang.
+  actions:
+    - text: Kom i gang
+      link: /da/introduction/
+      icon: right-arrow
+    - text: Se på GitHub
+      link: https://github.com/onetimesecret/onetimesecret
+      icon: external
+      variant: minimal
+---
+
+## Kraften i sikker deling
+
+Onetime Secret giver en simpel, sikker måde at dele følsom information. Vores tjeneste sikrer, at dine data forbliver private og midlertidige i en stadig mere permanent digital verden.
+
+{% cardgrid %}
+{% card title="Selvdestruerende beskeder" icon="trash" %}
+Del beskeder, der automatisk slettes efter at være blevet set eller efter et fastsat tidspunkt.
+{% /card %}
+{% card title="Server-side kryptering" icon="lock-closed" %}
+Dine beskeder er sikkert krypteret på vores servere, hvilket sikrer databeskyttelse.
+{% /card %}
+{% card title="Adgangssætningsbeskyttelse" icon="key" %}
+Tilføj et ekstra lag af sikkerhed med brugerdefinerede adgangssætninger til dine delte beskeder.
+{% /card %}
+{% /cardgrid %}
+
+## Fleksibiliteten i vores tjeneste
+
+Onetime Secret tilbyder tilpassede muligheder for at opfylde dine specifikke behov, uanset om du er en privatperson eller en virksomhed, der søger en branded løsning.
+
+{% cardgrid %}
+{% card title="Tilpasset udløb" icon="clock" %}
+Indstil din besked til at udløbe efter et bestemt tidspunkt, fra minutter til dage.
+{% /card %}
+{% card title="Brugerdefinerede domæner" icon="globe-alt" %}
+Brug dit eget domæne for en personlig og branded oplevelse.
+{% /card %}
+{% card title="Open source" icon="code-bracket" %}
+Vores gennemsigtige, fællesskabsreviderede kodebase sikrer tillid og pålidelighed.
+{% /card %}
+{% /cardgrid %}
+
+## Hvorfor vælge Onetime Secret?
+
+Onetime Secret tilbyder en sikker, compliant og brugervenlig platform til deling af følsom information, der prioriterer dit privatliv og databeskyttelse.
+
+{% cardgrid %}
+{% card title="Privatlivs-først design" icon="shield-check" %}
+Bygget fra bunden med privatliv i tankerne, hvilket sikrer, at dine følsomme data forbliver fortrolige og beskyttede.
+{% /card %}
+{% card title="Brugerdefinerede domæner" icon="lock-closed" %}
+State-of-the-art netværksarkitektur giver mulighed for datalokalisering og integration af brugerdefinerede domæner, hvilket giver en branded og compliant oplevelse.
+{% /card %}
+{% card title="Selvdestruerende beskeder" icon="clock" %}
+Beskeder slettes automatisk efter et fastsat tidspunkt eller enkelt visning, hvilket minimerer digitale fodspor og forbedrer sikkerheden.
+{% /card %}
+{% card title="Compliance-klar" icon="document-check" %}
+Designet til at hjælpe med at opfylde globale privatlivsregler, herunder GDPR-, CCPA- og HIPAA-krav.
+{% /card %}
+{% card title="Open-source gennemsigtighed" icon="code-bracket" %}
+Vores open-source model sikrer gennemsigtighed og giver mulighed for fællesskabsdrevne sikkerhedsforbedringer.
+{% /card %}
+{% card title="Brugervenlig grænseflade" icon="user-group" %}
+Intuitivt design gør sikker informationsdeling tilgængelig for både tekniske og ikke-tekniske brugere.
+{% /card %}
+{% /cardgrid %}
+
+## Forbedr dit privatliv i dag
+
+Slut dig til de tusindvis af brugere, der stoler på Onetime Secret til sikker, midlertidig deling. Familiedrevet siden 2012.
+
+[Udforsk Premium-planer](/da/pricing/) | [Prøv gratis](/da/introduction/)

--- a/src/content/docs/pt-br/index.mdoc
+++ b/src/content/docs/pt-br/index.mdoc
@@ -1,0 +1,80 @@
+---
+title: Onetime Secret - Links seguros, conexões mais fortes
+description: Onetime Secret oferece uma maneira segura e temporária de compartilhar informações confidenciais em um mundo digital.
+tableOfContents:
+  minHeadingLevel: 3
+hero:
+  title: Links seguros, conexões mais fortes
+  tagline: Compartilhe informações confidenciais de forma segura com links autodestrutivos que podem ser visualizados apenas uma vez.
+  actions:
+    - text: Começar
+      link: /pt-br/introduction/
+      icon: right-arrow
+    - text: Ver no GitHub
+      link: https://github.com/onetimesecret/onetimesecret
+      icon: external
+      variant: minimal
+---
+
+## O poder do compartilhamento seguro
+
+Onetime Secret oferece uma maneira simples e segura de compartilhar informações confidenciais. Nosso serviço garante que seus dados permaneçam privados e temporários em um mundo digital cada vez mais permanente.
+
+{% cardgrid %}
+{% card title="Mensagens autodestrutivas" icon="trash" %}
+Compartilhe mensagens que são excluídas automaticamente após serem visualizadas ou após um tempo definido.
+{% /card %}
+{% card title="Criptografia do lado do servidor" icon="lock-closed" %}
+Suas mensagens são criptografadas com segurança em nossos servidores, garantindo a proteção de dados.
+{% /card %}
+{% card title="Proteção por frase secreta" icon="key" %}
+Adicione uma camada extra de segurança com frases secretas personalizadas para suas mensagens compartilhadas.
+{% /card %}
+{% /cardgrid %}
+
+## A flexibilidade do nosso serviço
+
+Onetime Secret oferece opções personalizáveis para atender às suas necessidades específicas, seja você um indivíduo ou uma empresa em busca de uma solução com marca personalizada.
+
+{% cardgrid %}
+{% card title="Expiração personalizável" icon="clock" %}
+Defina que sua mensagem expire após um tempo específico, de minutos a dias.
+{% /card %}
+{% card title="Domínios personalizados" icon="globe-alt" %}
+Use seu próprio domínio para uma experiência personalizada e com marca.
+{% /card %}
+{% card title="Código aberto" icon="code-bracket" %}
+Nossa base de código transparente e auditada pela comunidade garante confiança e confiabilidade.
+{% /card %}
+{% /cardgrid %}
+
+## Por que escolher o Onetime Secret?
+
+Onetime Secret oferece uma plataforma segura, em conformidade e fácil de usar para compartilhar informações confidenciais, priorizando sua privacidade e proteção de dados.
+
+{% cardgrid %}
+{% card title="Design com privacidade em primeiro lugar" icon="shield-check" %}
+Construído desde o início com privacidade em mente, garantindo que seus dados confidenciais permaneçam privados e protegidos.
+{% /card %}
+{% card title="Domínios personalizados" icon="lock-closed" %}
+Arquitetura de rede de última geração permite localização de dados e integração de domínio personalizado, proporcionando uma experiência com marca e em conformidade.
+{% /card %}
+{% card title="Mensagens autodestrutivas" icon="clock" %}
+As mensagens são excluídas automaticamente após um tempo definido ou visualização única, minimizando pegadas digitais e aumentando a segurança.
+{% /card %}
+{% card title="Pronto para conformidade" icon="document-check" %}
+Projetado para ajudar a atender aos regulamentos globais de privacidade, incluindo requisitos de GDPR, CCPA e HIPAA.
+{% /card %}
+{% card title="Transparência de código aberto" icon="code-bracket" %}
+Nosso modelo de código aberto garante transparência e permite melhorias de segurança impulsionadas pela comunidade.
+{% /card %}
+{% card title="Interface amigável" icon="user-group" %}
+Design intuitivo torna o compartilhamento seguro de informações acessível para usuários técnicos e não técnicos.
+{% /card %}
+{% /cardgrid %}
+
+## Melhore sua privacidade hoje
+
+Junte-se aos milhares de usuários que confiam no Onetime Secret para compartilhamento seguro e temporário. Operado por família desde 2012.
+
+[Explorar planos Premium](/pt-br/pricing/) | [Experimentar gratuitamente](/pt-br/introduction/)

--- a/src/content/docs/sv/index.mdoc
+++ b/src/content/docs/sv/index.mdoc
@@ -1,0 +1,80 @@
+---
+title: Onetime Secret - Säkra länkar, starkare kontakter
+description: Onetime Secret erbjuder ett säkert, tillfälligt sätt att dela känslig information i en digital värld.
+tableOfContents:
+  minHeadingLevel: 3
+hero:
+  title: Säkra länkar, starkare kontakter
+  tagline: Dela känslig information säkert med självförstörande länkar som bara kan visas en gång.
+  actions:
+    - text: Kom igång
+      link: /sv/introduction/
+      icon: right-arrow
+    - text: Visa på GitHub
+      link: https://github.com/onetimesecret/onetimesecret
+      icon: external
+      variant: minimal
+---
+
+## Kraften i säker delning
+
+Onetime Secret ger ett enkelt, säkert sätt att dela känslig information. Vår tjänst säkerställer att dina data förblir privata och tillfälliga i en alltmer permanent digital värld.
+
+{% cardgrid %}
+{% card title="Självförstörande meddelanden" icon="trash" %}
+Dela hemligheter som automatiskt raderas efter att ha visats eller efter en angiven tid.
+{% /card %}
+{% card title="Kryptering på serversidan" icon="lock-closed" %}
+Dina hemligheter är säkert krypterade på våra servrar, vilket säkerställer dataskydd.
+{% /card %}
+{% card title="Lösenfrasskydd" icon="key" %}
+Lägg till ett extra lager av säkerhet med anpassade lösenfraser för dina delade hemligheter.
+{% /card %}
+{% /cardgrid %}
+
+## Flexibiliteten i vår tjänst
+
+Onetime Secret erbjuder anpassningsbara alternativ för att möta dina specifika behov, oavsett om du är en privatperson eller ett företag som söker en varumärkesanpassad lösning.
+
+{% cardgrid %}
+{% card title="Anpassningsbar utgång" icon="clock" %}
+Ställ in din hemlighet att gå ut efter en specifik tid, från minuter till dagar.
+{% /card %}
+{% card title="Anpassade domäner" icon="globe-alt" %}
+Använd din egen domän för en personlig och varumärkesanpassad upplevelse.
+{% /card %}
+{% card title="Öppen källkod" icon="code-bracket" %}
+Vår transparenta, gemenskapsgranskade kodbas säkerställer förtroende och tillförlitlighet.
+{% /card %}
+{% /cardgrid %}
+
+## Varför välja Onetime Secret?
+
+Onetime Secret erbjuder en säker, regelefterlevande och användarvänlig plattform för att dela känslig information, som prioriterar din integritet och dataskydd.
+
+{% cardgrid %}
+{% card title="Integritetsfokuserad design" icon="shield-check" %}
+Byggd från grunden med integritet i åtanke, vilket säkerställer att dina känsliga data förblir konfidentiella och skyddade.
+{% /card %}
+{% card title="Anpassade domäner" icon="lock-closed" %}
+Den senaste nätverksarkitekturen möjliggör datalokalisering och integration av anpassade domäner, vilket ger en varumärkesanpassad och regelefterlevande upplevelse.
+{% /card %}
+{% card title="Självförstörande meddelanden" icon="clock" %}
+Meddelanden raderas automatiskt efter en angiven tid eller enskild visning, vilket minimerar digitala fotspår och förbättrar säkerheten.
+{% /card %}
+{% card title="Regelefterlevande" icon="document-check" %}
+Utformad för att hjälpa till att uppfylla globala integritetregler, inklusive GDPR-, CCPA- och HIPAA-krav.
+{% /card %}
+{% card title="Öppen källkod transparens" icon="code-bracket" %}
+Vår öppna källkodsmodell säkerställer transparens och möjliggör gemenskapsdrivna säkerhetsförbättringar.
+{% /card %}
+{% card title="Användarvänligt gränssnitt" icon="user-group" %}
+Intuitiv design gör säker informationsdelning tillgänglig för både tekniska och icke-tekniska användare.
+{% /card %}
+{% /cardgrid %}
+
+## Förbättra din integritet idag
+
+Gå med i tusentals användare som litar på Onetime Secret för säker, tillfällig delning. Familjeägd sedan 2012.
+
+[Utforska Premium-planer](/sv/pricing/) | [Prova gratis](/sv/introduction/)

--- a/src/content/docs/tr/index.mdoc
+++ b/src/content/docs/tr/index.mdoc
@@ -1,0 +1,80 @@
+---
+title: Onetime Secret - Güvenli bağlantılar, daha güçlü bağlantılar
+description: Onetime Secret, dijital dünyada hassas bilgileri paylaşmak için güvenli ve geçici bir yöntem sunar.
+tableOfContents:
+  minHeadingLevel: 3
+hero:
+  title: Güvenli bağlantılar, daha güçlü bağlantılar
+  tagline: Hassas bilgileri yalnızca bir kez görüntülenebilen, kendi kendini yok eden bağlantılarla güvenle paylaşın.
+  actions:
+    - text: Başlayın
+      link: /tr/introduction/
+      icon: right-arrow
+    - text: GitHub'da görüntüle
+      link: https://github.com/onetimesecret/onetimesecret
+      icon: external
+      variant: minimal
+---
+
+## Güvenli paylaşımın gücü
+
+Onetime Secret, hassas bilgileri paylaşmak için basit ve güvenli bir yol sağlar. Hizmetimiz, giderek daha kalıcı hale gelen dijital dünyada verilerinizin gizli ve geçici kalmasını sağlar.
+
+{% cardgrid %}
+{% card title="Kendini yok eden mesajlar" icon="trash" %}
+Görüntülendikten veya belirlenen bir süreden sonra otomatik olarak silinen gizli mesajlar paylaşın.
+{% /card %}
+{% card title="Sunucu tarafı şifreleme" icon="lock-closed" %}
+Gizli mesajlarınız sunucularımızda güvenli bir şekilde şifrelenir ve veri koruması sağlar.
+{% /card %}
+{% card title="Güvenlik ifadesi koruması" icon="key" %}
+Paylaşılan gizli mesajlarınız için özel güvenlik ifadeleri ile ekstra bir güvenlik katmanı ekleyin.
+{% /card %}
+{% /cardgrid %}
+
+## Hizmetimizin esnekliği
+
+Onetime Secret, bir birey veya markalı bir çözüm arayan bir işletme olmanızdan bağımsız olarak, özel ihtiyaçlarınızı karşılamak için özelleştirilebilir seçenekler sunar.
+
+{% cardgrid %}
+{% card title="Özelleştirilebilir son kullanma tarihi" icon="clock" %}
+Gizli mesajınızın belirli bir süre sonra, dakikalardan günlere kadar süre dolacak şekilde ayarlayın.
+{% /card %}
+{% card title="Özel alan adları" icon="globe-alt" %}
+Kişiselleştirilmiş ve markalı bir deneyim için kendi alan adınızı kullanın.
+{% /card %}
+{% card title="Açık kaynak" icon="code-bracket" %}
+Şeffaf, topluluk tarafından denetlenen kod tabanımız güven ve güvenilirlik sağlar.
+{% /card %}
+{% /cardgrid %}
+
+## Neden Onetime Secret'ı seçmelisiniz?
+
+Onetime Secret, gizliliğinizi ve veri korumanızı önceliklendirerek hassas bilgileri paylaşmak için güvenli, uyumlu ve kullanıcı dostu bir platform sunar.
+
+{% cardgrid %}
+{% card title="Gizlilik odaklı tasarım" icon="shield-check" %}
+Baştan sona gizlilik göz önünde bulundurularak oluşturuldu ve hassas verilerinizin gizli ve korumalı kalmasını sağlar.
+{% /card %}
+{% card title="Özel alan adları" icon="lock-closed" %}
+Son teknoloji ağ mimarisi, veri yerelleştirmesi ve özel alan adı entegrasyonu sağlayarak markalı ve uyumlu bir deneyim sunar.
+{% /card %}
+{% card title="Kendini yok eden mesajlar" icon="clock" %}
+Mesajlar belirlenen bir süre sonra veya tek görüntülemeden sonra otomatik olarak silinir, dijital ayak izlerini en aza indirir ve güvenliği artırır.
+{% /card %}
+{% card title="Uyumluluk hazır" icon="document-check" %}
+GDPR, CCPA ve HIPAA gereksinimleri de dahil olmak üzere küresel gizlilik düzenlemelerini karşılamaya yardımcı olmak için tasarlanmıştır.
+{% /card %}
+{% card title="Açık kaynak şeffaflığı" icon="code-bracket" %}
+Açık kaynak modelimiz şeffaflığı sağlar ve topluluk odaklı güvenlik iyileştirmelerine olanak tanır.
+{% /card %}
+{% card title="Kullanıcı dostu arayüz" icon="user-group" %}
+Sezgisel tasarım, hem teknik hem de teknik olmayan kullanıcılar için güvenli bilgi paylaşımını erişilebilir hale getirir.
+{% /card %}
+{% /cardgrid %}
+
+## Gizliliğinizi bugün geliştirin
+
+Güvenli, geçici paylaşım için Onetime Secret'a güvenen binlerce kullanıcıya katılın. 2012'den beri aile işletmesi.
+
+[Premium planları keşfedin](/tr/pricing/) | [Ücretsiz deneyin](/tr/introduction/)


### PR DESCRIPTION
Created homepage index.mdoc files for four languages that had complete content structures but were missing the main homepage file:

- Danish (da): Translated with "besked" terminology following language notes
- Portuguese Brazil (pt-br): Used "mensagem confidencial" for secret
- Swedish (sv): Translated with "hemlighet" and proper voice guidelines
- Turkish (tr): Used "gizli mesaj" following the same pattern as Danish

Each translation was carefully crafted based on the respective language's:
- Glossary for consistent terminology
- Style guide for tone and voice
- Language notes for specific translation decisions

All translations maintain the professional, security-focused brand voice while being natural to native speakers.