### PR TITLE
Fix Italian locale link issues and formatting

### DIFF
--- a/src/content/docs/it/custom-domains/how-it-works.md
+++ b/src/content/docs/it/custom-domains/how-it-works.md
@@ -14,18 +14,18 @@ Sfruttando i domini personalizzati, non vi limitate a condividere i segreti, ma 
 
 1. Registrate un dominio o utilizzate quello che già possedete.
 2. Scegliete la regione del centro dati che preferite (UE o USA).
-3. [Configurate le impostazioni DNS del vostro dominio] (/docs/custom-domains/setup-guide) per puntare ai server di Onetime Secret nella regione prescelta.
+3. [Configurate le impostazioni DNS del vostro dominio](/it/custom-domains/setup-guide) per puntare ai server di Onetime Secret nella regione prescelta.
 4. Configurare il dominio personalizzato nelle impostazioni dell'account Onetime Secret.
 5. Una volta verificati, i link segreti utilizzeranno il dominio personalizzato.
-6. [Personalizzate l'aspetto del vostro dominio](custom-domains/brand-guide) con loghi e colori del marchio attraverso l'interfaccia di amministrazione.
+6. [Personalizzate l'aspetto del vostro dominio](/it/custom-domains/brand-guide) con loghi e colori del marchio attraverso l'interfaccia di amministrazione.
 
 
 ## Risoluzione dei problemi di configurazione più comuni
 
 - **Propagazione DNS**: Le modifiche possono richiedere fino a 48 ore per propagarsi completamente. Siate pazienti e riprovate più tardi se la verifica non riesce inizialmente.
 - **Registri DNS errati**: Ricontrollare le impostazioni DNS in base alle istruzioni fornite per la regione scelta.
-- Problemi con il certificato SSL**: Contattare il nostro team di assistenza se si riscontrano problemi relativi all'SSL.
-- Verifica della proprietà del dominio**: Assicurarsi di avere il pieno controllo del dominio che si sta cercando di configurare.
-- Selezione della regione**: Se non siete sicuri di quale regione scegliere, consultate la nostra guida [Data Center Regions](regions) o contattate il nostro team di assistenza.
+- **Problemi con il certificato SSL**: Contattare il nostro team di assistenza se si riscontrano problemi relativi all'SSL.
+- **Verifica della proprietà del dominio**: Assicurarsi di avere il pieno controllo del dominio che si sta cercando di configurare.
+- **Selezione della regione**: Se non siete sicuri di quale regione scegliere, consultate la nostra guida [Regioni dei centri dati](/it/regions) o contattate il nostro team di assistenza.
 
-Per conoscere le migliori pratiche per l'utilizzo sicuro dei domini personalizzati, consultate la nostra guida [Security Best Practices](security-best-practices).
+Per conoscere le migliori pratiche per l'utilizzo sicuro dei domini personalizzati, consultate la nostra guida [Best practice di sicurezza](/it/security-best-practices).


### PR DESCRIPTION
- Fix malformed markdown link on line 17 (removed space between ] and ()
- Add /it/ locale prefix to all internal links
- Translate remaining English link text to Italian:
  - "Data Center Regions" → "Regioni dei centri dati"
  - "Security Best Practices" → "Best practice di sicurezza"
- Fix bold marker consistency (add opening ** to lines 27-29)

Resolves high and medium priority issues from Italian locale quality analysis.