### PR TITLE
Add Chinese Simplified self-hosting documentation

### DIFF
--- a/src/content/docs/zh-cn/self-hosting/configuration.md
+++ b/src/content/docs/zh-cn/self-hosting/configuration.md
@@ -1,0 +1,461 @@
+---
+title: 配置参考
+description: 所有 Onetime Secret 配置选项的完整参考
+sidebar:
+  order: 4
+---
+
+
+本综合指南涵盖了自托管 Onetime Secret 实例的所有配置选项。
+
+## 配置文件
+
+Onetime Secret 使用多个配置文件：
+
+
+- **`.env`** - 常用设置的环境变量。用于简单配置和 Docker 部署，无需修改 YAML 文件。（从 `.env.example` 复制）
+- **`config/config.yaml`** - 使用 ERB 模板的主应用程序配置。环境变量在此处集成，便于查看每个设置的应用方式。（从 `etc/config.example.yaml` 复制）
+
+
+## 主配置
+
+主配置文件是 `config/config.yaml`，它使用 ERB 模板集成环境变量。
+
+**入门：**
+1. 复制示例：`cp etc/config.example.yaml config/config.yaml`
+2. 根据您的部署需要编辑值
+3. 大多数常用设置可以使用环境变量覆盖
+
+**查看完整的配置文件：**
+[config.example.yaml](https://raw.githubusercontent.com/onetimesecret/onetimesecret/refs/tags/v0.22.4/etc/config.example.yaml)
+
+### 关键配置部分
+
+以下是您可能需要自定义的最重要部分：
+
+```yaml
+---
+:site:
+  :host: <%= ENV['HOST'] || 'localhost:3000' %>
+  # 生成链接时打开或关闭 https/http
+  :ssl: <%= ENV['SSL'] == 'true' || false %>
+  # 重要提示：设置密钥后，不应更改它。
+  # 请务必在安全的异地位置创建并存储备份。
+  # 更改密钥可能会导致无法预见的问题，
+  # 例如无法解密现有机密内容。
+  :secret: <%= ENV['SECRET'] || nil %>
+  # API 和 UI 配置
+  :interface:
+    :ui:
+      # 控制是否启用 Web 界面
+      # 当为 false 时，仅显示基本说明页面
+      :enabled: <%= ENV['UI_ENABLED'] != 'false' %>
+      # 标头配置
+      # 控制站点标头中的品牌和导航
+      :header:
+        # 控制开关以启用/禁用标头自定义
+        :enabled: <%= ENV['HEADER_ENABLED'] != 'false' %>
+        # 徽标和公司名称的品牌配置
+        :branding:
+          # 徽标配置
+          :logo:
+            # 徽标图像文件的 URL
+            :url: <%= ENV['LOGO_URL'] || 'DefaultLogo.vue' %>
+            # 徽标图像的替代文本
+            :alt: <%= ENV['LOGO_ALT'] || 'Share a Secret One-Time' %>
+            # 单击徽标时链接到的位置
+            :href: <%= ENV['LOGO_LINK'] || '/' %>
+          # 公司名称覆盖（如果未设置，则回退到 i18n）
+          :site_name: <%= ENV['SITE_NAME'] || 'One-Time Secret' %>
+        # 导航配置
+        :navigation:
+          # 完全启用/禁用标头导航
+          :enabled: <%= ENV['HEADER_NAV_ENABLED'] != 'false' %>
+      # 页脚链接配置
+      # 这些链接显示在每个页面的页脚中
+      :footer_links:
+        # 主开关以启用/禁用所有页脚链接
+        :enabled: <%= ENV['FOOTER_LINKS'] == 'true' || false %>
+        # 组织的链接组
+        :groups:
+          - :name: legal
+            :i18n_key: web.footer.legals
+            :links:
+              - :text: Terms of Service
+                :i18n_key: terms-of-service
+                # 替换为您自己的条款 URL 或使用相对路径，如 /terms
+                :url: <%= ENV['TERMS_URL']  %>
+                :external: <%= ENV['TERMS_EXTERNAL'] || false %>
+              - :text: Privacy Policy
+                :i18n_key: privacy-policy
+                # 替换为您自己的隐私 URL 或使用相对路径，如 /privacy
+                :url: <%= ENV['PRIVACY_URL']  %>
+                :external: <%= ENV['PRIVACY_EXTERNAL'] || false %>
+          - :name: resources
+            :i18n_key: web.footer.resources
+            :links:
+              - :text: Status
+                :i18n_key: status
+                # 如果您有状态页面，请替换为您的状态页面 URL
+                :url: <%= ENV['STATUS_URL'] %>
+                :external: <%= ENV['STATUS_EXTERNAL'] || true %>
+                :icon: signal
+              - :text: About
+                :i18n_key: web.COMMON.about
+                # 替换为您的关于页面 URL
+                :url: <%= ENV['ABOUT_URL'] %>
+                :external: <%= ENV['ABOUT_EXTERNAL'] || false %>
+          - :name: support
+            :i18n_key: web.footer.support
+            :links:
+              - :text: Contact
+                :i18n_key: web.footer.contact
+                :url: <%= ENV['CONTACT_URL'] %>
+                :external: false
+    # 控制 API 端点是否可用。禁用时，API
+    # 完全禁用。对 /api/* 的请求将返回 404。
+    :api:
+      :enabled: <%= ENV['API_ENABLED'] != 'false' %>
+  # 机密内容管理的配置选项
+  :secret_options:
+    # 机密内容的默认生存时间（TTL），以秒为单位
+    # 如果在创建机密内容时未提供特定 TTL，则使用此值
+    :default_ttl: <%= ENV['DEFAULT_TTL'] || nil %>
+    # 创建机密内容的可用 TTL 选项（以秒为单位）
+    # 这些选项将在用户创建新机密内容时呈现给用户
+    # 格式：表示秒数的整数字符串
+    :ttl_options: <%= (ENV['TTL_OPTIONS'] || nil) %>
+    # 保护访问机密内容的口令字段设置
+    :passphrase:
+      # 要求用户在创建机密内容时输入口令
+      :required: <%= ENV['PASSPHRASE_REQUIRED'] == 'true' || false %>
+      # 口令所需的最小字符数
+      :minimum_length: <%= ENV['PASSPHRASE_MIN_LENGTH'] || 8 %>
+      # 口令允许的最大字符数
+      :maximum_length: <%= ENV['PASSPHRASE_MAX_LENGTH'] || 128 %>
+      # 强制复杂性要求（大写、小写、数字、符号）
+      :enforce_complexity: <%= ENV['PASSPHRASE_ENFORCE_COMPLEXITY'] == 'true' || false %>
+    # 密码生成设置（当用户单击"生成密码"时）
+    :password_generation:
+      # 生成的密码的默认长度
+      :default_length: <%= ENV['PASSWORD_GEN_LENGTH'] || 12 %>
+      # 要包含在生成的密码中的字符集
+      :character_sets:
+        # 包含大写字母（A-Z）
+        :uppercase: <%= ENV['PASSWORD_GEN_UPPERCASE'] != 'false' %>
+        # 包含小写字母（a-z）
+        :lowercase: <%= ENV['PASSWORD_GEN_LOWERCASE'] != 'false' %>
+        # 包含数字（0-9）
+        :numbers: <%= ENV['PASSWORD_GEN_NUMBERS'] != 'false' %>
+        # 包含符号（!@#$%^&*()_+-=[]{}|;:,.<>?）
+        :symbols: <%= ENV['PASSWORD_GEN_SYMBOLS'] == 'true' || false %>
+        # 排除易混淆的字符（0、O、l、1、I）以防止混淆
+        :exclude_ambiguous: <%= ENV['PASSWORD_GEN_EXCLUDE_AMBIGUOUS'] != 'false' %>
+  # 注册和身份验证设置
+  :authentication:
+    # 可以完全禁用，包括 API 身份验证。
+    :enabled: <%= ENV['AUTH_ENABLED'] != 'false' %>
+    # 允许用户创建帐户。如果您计划手动创建帐户或
+    # 在设置期间启用帐户创建，然后禁用以防止任何新用户
+    # 创建帐户，则可以禁用此功能。
+    :signup: <%= ENV['AUTH_SIGNUP'] != 'false' %>
+    # 通常，如果您允许注册，则允许登录。但在某些情况下，
+    # 暂时关闭身份验证是有帮助的。
+    :signin: <%= ENV['AUTH_SIGNIN'] != 'false' %>
+    # 默认情况下，新帐户需要在登录之前验证其电子邮件地址。
+    # 这是一项安全措施，可防止垃圾邮件和系统滥用。如果您正在
+    # 运行私有实例或为您的团队或公司运行实例，您可以禁用此功能
+    # 以便用户更轻松地登录。
+    :autoverify: <%= ENV['AUTH_AUTOVERIFY'] == 'true' || false %>
+    # 启用时，除非用户已登录，否则主页机密内容表单不可用。
+    # 类似于禁用的主页，但仍显示带有徽标和导航链接的标头。
+    # 这允许更严格的模式，其中只有经过身份验证的用户才能创建
+    # 机密内容，同时保持站点导航和品牌。
+    :required: <%= ENV['AUTH_REQUIRED'] == 'true' %>
+    # 下面列出的电子邮件地址将在帐户创建时自动授予
+    # 管理权限。这些帐户可以访问显示基本系统统计信息的页面。
+    # 使用术语"colonel"而不是"admin"。"Colonel"（发音为"kernel"）
+    # 既指 Linux 系统的受保护核心，也指军衔，象征着高级访问
+    # 权限。此命名有助于避免针对常见管理 URL 或角色名称的基本自动攻击。
+    :colonels:
+      - <%= ENV['COLONEL'] || 'CHANGEME@example.com' %>
+  # 一种类似验证码的功能，可保护反馈表单
+  # 免受机器人和其他恶作剧的侵害。
+  :authenticity:
+    :type: <%= ENV['AUTHENTICITY_TYPE'] || 'altcha' %>
+    :secret_key: <%= ENV['AUTHENTICITY_SECRET_KEY'] || '<REPLACE_WITH_STRONG_HMAC_KEY>' %>
+  # 文档链接。对于 onetimesecret.com，这是
+  # docs.onetimesecret.com。
+  :support:
+    :host: <%= ENV['SUPPORT_HOST'] || nil %>
+  :plans:
+    :enabled: <%= ENV['PLANS_ENABLED'] == 'true' || false %>
+    :stripe_key: <%= ENV['STRIPE_KEY'] || nil %>
+  :regions:
+    :enabled: <%= ENV['REGIONS_ENABLED'] == 'true' || false %>
+    :current_jurisdiction: <%= ENV['JURISDICTION'] || nil %>
+  :domains:
+    :enabled: <%= ENV['DOMAINS_ENABLED'] == 'true' || false %>
+    # 用于链接 URL 的默认域。当未设置或为空时，
+    # 使用 site.host。
+    :default: <%= ENV['DEFAULT_DOMAIN'] || nil %>
+    # 集群类型确定应用程序将如何支持
+    # 多个域。默认值为 nil，这意味着
+    # 应用程序本身负责处理多个域。
+    :cluster:
+      :type: <%= ENV['CLUSTER_TYPE'] || nil %>
+      :api_key: <%= ENV['APPROXIMATED_API_KEY'] || nil %>
+      :cluster_ip: <%= ENV['APPROXIMATED_PROXY_CLUSTER_IP'] || '<CLUSTER_IP>' %>
+      :cluster_host: <%= ENV['APPROXIMATED_PROXY_CLUSTER_HOST'] || '<CLUSTER_HOST>' %>
+      :cluster_name: <%= ENV['APPROXIMATED_PROXY_CLUSTER_NAME'] || '<CLUSTER_NAME>' %>
+      :vhost_target: <%= ENV['APPROXIMATED_PROXY_VHOST_TARGET'] || '<VHOST_TARGET>' %>
+:features:
+  :incoming:
+    :enabled: false
+    :email: CHANGEME@example.com
+    :passphrase: abacus
+# Redis 配置
+:redis:
+  # 主 Redis 连接 URI - 指定完整的连接字符串（包括身份验证）
+  # 格式：redis://[:password@]host[:port]/[db-number]
+  # 示例：
+  #   - redis://mypassword@localhost:6379/0        # 简单密码身份验证
+  #   - redis://user:pass@localhost:6379/0         # 用户名/密码身份验证
+  #   - redis://redis.example.com:6379/0          # 无身份验证（仅开发）
+  :uri: <%= ENV['REDIS_URL'] || 'redis://CHANGEME@127.0.0.1:6379/0' %>
+
+# 日志配置
+:logging:
+  # HTTP 请求日志（Rack::CommonLogger）
+  :http_requests: <%= ENV['LOG_HTTP_REQUESTS'] != 'false' %>
+
+# 发送电子邮件
+:emailer:
+  # 使用 Mailpit 进行本地开发
+  # -----------------------------
+  # Mailpit 是一个用于捕获电子邮件以进行测试的开发 SMTP 服务器
+  # 安装：brew install mailpit
+  # 启动：mailpit
+  # Web UI：http://localhost:8025
+  #
+  #  :mode: smtp                      # 使用 SMTP 模式进行本地测试
+  #  :from: secure@onetimesecret.com # 发件人地址
+  #  :fromname: OTS Support          # 发件人姓名
+  #  :host: 127.0.0.1                # Mailpit 主机
+  #  :port: 1025                     # Mailpit 默认 SMTP 端口
+  #  :user: ~                        # Mailpit 不需要身份验证
+  #  :pass: ~                        # Mailpit 不需要身份验证
+  #  :auth: false                    # 禁用 Mailpit 的 SMTP 身份验证
+  #  :tls: false                     # 禁用本地测试的 TLS
+
+  # 生产设置（供参考）
+  # ----------------------------------
+  :mode: <%= ENV['EMAILER_MODE'] || 'smtp' %>
+  :from: <%= ENV['FROM_EMAIL'] || ENV['FROM'] || 'CHANGEME@example.com' %>
+  :fromname: <%= ENV['FROMNAME'] || 'Support' %>
+  :host: <%= ENV['SMTP_HOST'] || 'smtp.provider.com' %>
+  :port: <%= ENV['SMTP_PORT'] || 587 %>
+  :user: <%= ENV['SMTP_USERNAME'] %>
+  :pass: <%= ENV['SMTP_PASSWORD'] %>
+  :auth: <%= ENV['SMTP_AUTH'] || 'login' %>
+  :tls: <%= ENV['SMTP_TLS'] %>
+
+:mail:
+  :truemail:
+    # 可用的验证类型：:regex、:mx、:mx_blacklist、:smtp
+    :default_validation_type: :regex
+    # :smtp 验证所需
+    :verifier_email: <%= ENV['VERIFIER_EMAIL'] || 'CHANGEME@example.com' %>
+    #:verifier_domain: <%= ENV['VERIFIER_DOMAIN'] || 'example.com' %>
+    #:connection_timeout: 2
+    #:response_timeout: 2
+    #:connection_attempts: 3
+    #:validation_type_for:
+    #  'example.com': :regex
+    #
+    # Truemail 将仅验证与
+    # :allowed_domains 中列出的域匹配的电子邮件地址。如果域未
+    # 列出，则电子邮件地址将始终被视为无效。
+    :allowed_domains_only: false
+    #
+    # 此列表中的电子邮件地址将始终有效。
+    #:allowed_emails: []
+    #
+    # 此列表中的电子邮件地址将始终无效。
+    #:blocked_emails: []
+    #
+    # 具有这些域的地址将始终有效
+    #:allowed_domains: []
+    #
+    # 具有这些域的地址将始终无效
+    #:blocked_domains: []
+    #
+    # 从 MX 查找过程中排除这些 IP 地址。
+    #:blocked_mx_ip_addresses: []
+    #
+    # 用于 MX 等记录查找的名称服务器。
+    # 默认为 CloudFlare、Google、Oracle/OpenDNS 服务器。
+    :dns:
+      - 1.1.1.1
+      - 8.8.4.4
+      - 208.67.220.220
+    #:smtp_port: 25
+    #
+    # 在第一次无效响应后结束 smtp 验证，而不是
+    # 重试，然后尝试下一个服务器。可以减少
+    # 验证电子邮件地址的时间，但可能无法捕获所有问题。
+    :smtp_fail_fast: false
+    #
+    # 解析 SMTP 错误消息的内容以确定
+    # 电子邮件地址是否有效。这对于某些不返回
+    # 确切答案的 SMTP 服务器可能很有用。
+    :smtp_safe_check: true
+    #
+    # 是否禁用 RFC MX 查找流程。当为 true 时，仅
+    # 对 MX 和 Null MX 记录执行 DNS 验证。
+    :not_rfc_mx_lookup_flow: false
+    #
+    # 覆盖电子邮件地址的默认正则表达式模式
+    # 和/或 SMTP 错误消息中的内容。
+    #:email_pattern: /regex_pattern/
+    #:smtp_error_body_pattern: /regex_pattern/
+    #
+    # 记录到控制台、文件或两者。ruby 进程必须具有
+    # 对日志文件的写访问权限。如果日志文件不存在，
+    # 将创建该文件。应用程序不处理日志文件轮换。
+    :logger:
+      # 以下之一：:error（默认）、:unrecognized_error、:recognized_error、:all。
+      :tracking_event: :error
+      :stdout: true
+      # log_absolute_path: '/home/app/log/truemail.log'
+
+:internationalization:
+  :enabled: <%= ENV['I18N_ENABLED'] == 'true' || false %>
+  :default_locale: <%= ENV['I18N_DEFAULT_LOCALE'] || 'en' %>
+  :fallback_locale:
+    fr-CA: [fr_CA, fr_FR, en]
+    fr: [fr_FR, fr_CA, en]
+    de-AT: [de_AT, de, en]
+    de: [de, de_AT, en]
+    it: [it_IT, en]
+    pt: [pt_BR, en]
+    default: [en]
+  # ISO 语言代码列表（例如，'en' 表示英语，'es'
+  # 表示西班牙语等）。src/locales 中有一个相应的文件
+  # 具有相同名称，其中包含翻译的文本。如果未
+  # 自动选择，用户可以使用页脚中的切换或
+  # 设置模态框（如果他们已登录）来选择其首选语言。
+  :locales:
+    - bg
+    - da_DK
+    - de
+    - de_AT
+    - el_GR
+    - en
+    - es
+    - fr_CA
+    - fr_FR
+    - it_IT
+    - ja
+    - ko
+    - mi_NZ
+    - nl
+    - tr
+    - uk
+    - pl
+    - pt_BR
+    - sv_SE
+
+:experimental:
+  # 安全功能：控制应用程序是否可以在没有
+  # site.secret（在此文件中或通过 SECRET 环境变量）的情况下运行。
+  #
+  # 默认值：false（如果 site.secret 为 nil，应用程序将无法启动）
+  #
+  # 警告：设置为 true 会带来重大安全风险：
+  # - 机密内容可能在没有适当加密的情况下存储
+  # - 可能未经授权访问敏感数据
+  # - 无法保证机密内容链接的完整性
+  #
+  # 有效用例（仅限临时）：
+  # 1. 恢复：您意外使用 nil 密钥运行，需要恢复
+  #    在该期间创建的现有机密内容。临时启用，直到
+  #    所有受影响的机密内容过期（最大 TTL 期限）。
+  # 2. 迁移：在加密方案之间进行受控迁移期间，
+  #    并采取适当的安全措施。
+  #
+  # 当为 TRUE 时的行为：
+  # - 应用程序启动而不会失败
+  # - 启动时出现警告日志
+  # - 解密时，使用真实密钥的 CipherErrors 将导致
+  #   使用 nil 密钥自动重试
+  #
+  :allow_nil_global_secret: <%= ENV['ALLOW_NIL_GLOBAL_SECRET'] == 'true' || false %>
+  # 安全功能：支持轮换全局密钥
+  #
+  # 格式：包含先前密钥值的字符串数组
+  # ["old_secret_1", "old_secret_2", "oldest_secret"]
+  #
+  # 用法：轮换密钥时，在此处添加旧值，同时在 site.secret 或 SECRET 环境变量中
+  # 设置新的主密钥。应用程序将：
+  # 1. 对所有新加密使用当前主密钥
+  # 2. 当主密钥失败时，尝试每个轮换的密钥（按顺序）进行解密
+  #
+  # 维护：在相关机密内容过期或已成功使用当前主密钥重新加密后，
+  # 从此列表中删除密钥。一个简单的指导原则是 `ttl_options` 中的最大 TTL。
+  :rotated_secrets: []
+  # 当设置为 true 时，Rack::Builder#freeze_app 在初始化后冻结中间件堆栈
+  # 以防止对应用程序中间件链进行任何运行时修改。这是一项安全措施，
+  # 可防止恶意代码注入新中间件。
+  #
+  # 效果：
+  # - 冻结中间件堆栈，防止在启动后添加/删除
+  # - 冻结传递给 Rack::Builder 的应用程序对象
+  # - 不影响请求/响应对象的可变性
+  #
+  # 注意：此设置可以通过防止在运行时操作中间件链来帮助使您的应用程序更安全。
+  # 对于大多数应用程序，应在生产环境中启用此功能。
+  :freeze_app: false
+  # 中间件配置
+  # 控制启用哪些安全和性能中间件组件
+  :middleware:
+    # 为前端 vue 应用程序提供静态文件
+    :static_files: true
+    # 清理请求参数以确保正确的 UTF-8 编码
+    # 防止基于编码的攻击和格式错误的输入
+    :utf8_sanitizer: true
+    # 防止跨站点请求伪造（CSRF）攻击
+    # 验证请求源自同一站点
+    :http_origin: false
+    # 转义请求参数中的 HTML 实体
+    # 有助于防止通过请求参数进行的 XSS 攻击
+    :escaped_params: false
+    # 设置 X-XSS-Protection 标头以启用浏览器 XSS 过滤
+    # 现代浏览器随着 CSP 成为标准而越来越少地依赖此功能
+    :xss_header: false
+    # 防止您的站点嵌入到框架中（点击劫持保护）
+    # 将 X-Frame-Options 标头设置为 SAMEORIGIN 或 DENY
+    :frame_options: false
+    # 使用路径中的"../"阻止目录遍历攻击
+    # 对于防止未经授权的文件访问至关重要
+    :path_traversal: false
+    # 防止 cookie 投掷攻击
+    # 通过操纵的 cookie 防止会话固定
+    :cookie_tossing: false
+    # 通过验证 IP 地址来防止 IP 欺骗攻击
+    # 在实施基于 IP 的访问控制时很有用
+    :ip_spoofing: false
+    # 通过 HSTS 标头强制所有连接使用 HTTPS
+    # 仅在开发或位于安全代理后时禁用
+    :strict_transport: false
+  # 启用时，将 Content-Security-Policy 标头添加到响应中。当
+  # `development.enabled=true` 时，标头将不那么严格，但仍会
+  # 防止从其他来源加载任何内容。在常规生产模式下，
+  # 安全随机数将包含在标头中，并且完全阻止 unsafe-inline 内容。
+  # 可以通过 rack 请求对象 `req.env['ots.nonce']` 访问随机数。
+  # 后端视图从那里抓取它，以自动将其添加到所有前端脚本和样式资源中。
+  # 只有在添加新脚本或样式依赖项时，才需要使用随机数。
+  # 禁用时，在任何环境中都不包含 csp 标头。
+  :csp:
+    :enabled: <%= ENV['CSP_ENABLED'] == 'true' || false %>
+```

--- a/src/content/docs/zh-cn/self-hosting/environment-variables.md
+++ b/src/content/docs/zh-cn/self-hosting/environment-variables.md
@@ -1,0 +1,146 @@
+---
+title: 环境变量参考
+description: Onetime Secret 环境变量的参考
+sidebar:
+  order: 5
+---
+
+本指南涵盖了 Onetime Secret v0.22.4+ 中可用的所有环境变量。
+
+
+## 环境变量
+
+在您的 `.env` 文件或环境中设置这些变量，或将它们添加到您的 docker 命令或 docker-compose.yml 文件中。除非标记为必需，否则所有变量都是可选的。
+
+### 核心应用程序设置
+
+```bash
+SECRET=your-32-char-hex-key           # 用于会话和加密的密钥（必需）- 设置后不要更改
+PORT=3000                             # Web 服务器监听的端口（默认：3000）
+HOST=localhost:3000                   # 用于生成链接的主机和端口组合
+SSL=true                              # 生成链接时控制 https/http（true/false）
+SERVER_TYPE=thin                      # Web 服务器类型：thin、puma
+RACK_ENV=production                   # 应用程序环境：development、production、test
+```
+
+### 数据库和存储
+
+注意：以 REDIS_ 开头的变量也可以使用 VALKEY_ 前缀设置。
+
+```bash
+REDIS_URL=redis://localhost:6379/0   # 用于会话、机密内容和所有应用程序数据的 Redis 连接字符串
+```
+
+### 身份验证和安全性
+
+```bash
+AUTH_ENABLED=true                     # 启用身份验证系统（为 false 时禁用 API 身份验证）
+AUTH_SIGNUP=true                      # 允许新用户注册
+AUTH_SIGNIN=true                      # 允许现有用户登录
+AUTH_AUTOVERIFY=false                 # 跳过新帐户的电子邮件验证
+COLONEL=email@example.com             # 授予"colonel"权限的管理员电子邮件地址（逗号分隔）
+```
+
+**注意**："Colonel"是我们对"admin"用户的术语。Colonels 可以访问 `/colonel` 的管理员区域，该区域显示基本系统统计信息。管理员界面目前功能有限 - 没有用户管理，只有只读配置查看。
+
+### 用户界面和功能
+
+```bash
+UI_ENABLED=true                       # 启用 Web 用户界面（禁用时显示最小页面）
+API_ENABLED=true                      # 启用 REST API 端点（禁用时返回 404）
+CSP_ENABLED=true                      # 启用内容安全策略标头
+HEADER_ENABLED=true                   # 显示带有品牌的站点标头
+HEADER_NAV_ENABLED=true               # 在标头中显示导航链接
+HEADER_PREFIX=
+DOMAINS_ENABLED=false                 # 启用自定义域支持
+REGIONS_ENABLED=false                 # 启用多区域部署支持。这不会影响
+                                      # 应用程序的功能。但它确实启用了
+                                      # 用于链接到其他区域的 UI 组件。
+```
+
+### 品牌和内容
+
+```bash
+LOGO_URL=                            # 自定义徽标图像的 URL（默认为内置徽标）
+LOGO_ALT=
+LOGO_LINK=
+FOOTER_LINKS=
+ABOUT_URL=
+ABOUT_EXTERNAL=false
+CONTACT_URL=
+PRIVACY_URL=
+PRIVACY_EXTERNAL=false
+TERMS_URL=
+TERMS_EXTERNAL=false
+STATUS_URL=
+STATUS_EXTERNAL=false
+```
+
+### 发送电子邮件
+
+```bash
+EMAILER_MODE=smtp                    # 电子邮件服务模式（smtp、sendgrid 等）
+EMAILER_REGION=                      # 电子邮件服务区域（用于云提供商）
+FROM_EMAIL=noreply@localhost         # 默认发件人电子邮件地址
+FROM=                                # 发件人姓名（FROMNAME 的替代方案）
+FROMNAME=                            # 发件人的显示名称
+SMTP_HOST=                           # SMTP 服务器主机名
+SMTP_PORT=587                        # SMTP 服务器端口（TLS 通常为 587，普通为 25）
+SMTP_USERNAME=                       # SMTP 身份验证用户名
+SMTP_PASSWORD=                       # SMTP 身份验证密码
+SMTP_TLS=true                        # 为 SMTP 启用 TLS 加密
+SMTP_AUTH=login                      # SMTP 身份验证方法（login、plain 等）
+```
+
+### 机密内容和 TTL
+
+```bash
+DEFAULT_TTL=604800                   # 默认机密内容过期时间（以秒为单位）（604800 = 7 天）
+TTL_OPTIONS=300,1800,3600,86400      # 呈现给用户的可用 TTL 选项，逗号分隔（秒）
+DEFAULT_DOMAIN=                      # 机密内容链接的默认域（如果为空，则使用 HOST）
+ALLOW_NIL_GLOBAL_SECRET=false        # 允许在缺少 SECRET 密钥的情况下操作（紧急恢复）
+```
+
+
+### 验证电子邮件地址
+
+电子邮件地址验证由 [Truemail 库](https://github.com/truemail-rb/truemail)处理，该库支持多种验证类型，包括正则表达式、MX 记录查找和 SMTP 验证。
+
+```bash
+VERIFIER_DOMAIN=                     # 用于 SMTP 验证的域（SMTP 验证所需）
+VERIFIER_EMAIL=                      # 用于 SMTP 验证的电子邮件地址（SMTP 验证所需）
+```
+
+**注意**：许多其他 Truemail 配置选项在 `truemail:` 部分下的 YAML 配置中可用，包括验证类型、超时设置、允许/阻止的域、DNS 服务器等。有关完整配置，请参阅 `config/config.yaml`。
+
+### 国际化
+
+```bash
+I18N_ENABLED=true                    # 启用国际化
+I18N_DEFAULT_LOCALE=en               # 默认语言区域设置
+```
+
+### 开发和调试
+
+```bash
+ONETIME_DEBUG=false                  # 启用调试模式
+LOG_HTTP_REQUESTS=false              # 记录 HTTP 请求
+STDOUT_SYNC=true                     # 同步 stdout 输出
+DIAGNOSTICS_ENABLED=false            # 启用诊断
+FRONTEND_HOST=http://localhost:5173  # 前端开发服务器 URL（仅开发）
+VITE_API_BASE_URL=                   # Vite API 基础 URL 覆盖
+```
+
+### 监控和错误跟踪
+
+有关配置 Sentry 的更多信息，请参阅 [sentry 文档](https://docs.sentry.io/platforms/ruby/)。
+
+```bash
+SENTRY_DSN=
+SENTRY_DSN_BACKEND=
+SENTRY_DSN_FRONTEND=
+SENTRY_LOG_ERRORS=true
+SENTRY_MAX_BREADCRUMBS=50
+SENTRY_SAMPLE_RATE=1.0
+SENTRY_VUE_TRACK_COMPONENTS=true
+```

--- a/src/content/docs/zh-cn/self-hosting/getting-started.md
+++ b/src/content/docs/zh-cn/self-hosting/getting-started.md
@@ -1,0 +1,88 @@
+---
+title: 入门指南
+description: 快速设置指南，让您的自托管 Onetime Secret 实例运行起来
+sidebar:
+  order: 2
+---
+
+本指南将帮助您在几分钟内启动并运行自托管的 Onetime Secret 实例。
+
+## 前提条件
+
+- **1GB 以上内存** 以获得最佳性能
+- **Redis 存储说明**：根据您的 Redis 配置，机密内容可以完全存储在内存中而不会写入磁盘，以增强安全性
+
+## 方法 1：Docker（推荐）
+
+使用 Docker 是最快的入门方式，只需最少的配置。
+
+### 1. 启动 Redis
+
+```bash
+docker run -p 6379:6379 -d redis:bookworm
+```
+
+### 2. 生成密钥
+
+```bash
+# 生成并存储持久化密钥
+openssl rand -hex 32 > .ots_secret
+chmod 600 .ots_secret
+echo "密钥已保存到 .ots_secret（请妥善保管此文件！）"
+```
+
+### 3. 运行 Onetime Secret
+
+```bash
+# 使用密钥运行容器
+docker run -p 3000:3000 -d \
+  -e REDIS_URL=redis://host.docker.internal:6379/0 \
+  -e SECRET="$(cat .ots_secret)" \
+  -e HOST=localhost:3000 \
+  -e SSL=false \
+  -e RACK_ENV=production \
+  onetimesecret/onetimesecret:latest
+```
+
+### 4. 访问您的实例
+
+在浏览器中打开：
+- **Web 界面**：http://localhost:3000
+- **API 端点**：http://localhost:3000/api/v2/status
+
+## 方法 2：手动安装
+
+对于喜欢手动设置的用户，您需要：
+
+- **Ruby 3.2+**（可能在默认系统软件包中不可用）
+- **Redis 5+** 或 **Valkey**（Redis 替代方案）
+- **Node.js 22+** 和 **pnpm**（仅用于开发和构建前端资源）
+
+在运行应用程序之前，您需要使用 `pnpm install && pnpm run build:local` 构建前端资源。
+
+有关完整的手动安装详细信息，请参阅 [INSTALL.md](https://github.com/onetimesecret/onetimesecret/blob/main/INSTALL.md)。
+
+## 验证
+
+1. 导航到 http://localhost:3000
+2. 创建一个测试机密内容以验证一切正常
+3. 在 http://localhost:3000/api/v2/status 检查 API 状态
+
+## 管理员设置
+
+要创建管理员用户，请在配置文件的 `:colonels:` 部分添加电子邮件地址，然后使用其中一个电子邮件注册以自动获得管理员访问权限。
+
+**注意**：管理员区域目前功能有限 - 它是只读配置查看，没有用户管理功能。未来版本计划提供更多功能。
+
+## 后续步骤
+
+现在您的实例已经运行：
+
+1. **[配置您的部署](./installation)** 用于生产使用
+2. **[查看配置选项](./configuration)** 进行自定义
+
+## 获取帮助
+
+- **文档**：浏览我们的[配置参考](./configuration)
+- **社区**：加入 [GitHub](https://github.com/onetimesecret/onetimesecret/discussions) 上的讨论
+- **问题**：在我们的[问题跟踪器](https://github.com/onetimesecret/onetimesecret/issues)上报告错误

--- a/src/content/docs/zh-cn/self-hosting/index.md
+++ b/src/content/docs/zh-cn/self-hosting/index.md
@@ -1,0 +1,67 @@
+---
+title: 自托管概述
+description: 运行您自己的 Onetime Secret 实例的完整指南
+sidebar:
+  order: 1
+---
+
+运行您自己的私有 Onetime Secret 实例，全面控制您的数据、安全性和部署。
+
+## 为什么要自托管？
+
+自托管 Onetime Secret 为您提供：
+
+- **完全的数据控制** - 所有机密内容保留在您的基础设施和网络中
+- **自定义安全策略** - 配置身份验证、隐私选项和访问控制
+- **合规性** - 满足数据处理的监管要求
+- **自定义品牌** - 为您的组织定制界面
+
+## 快速入门选项
+
+选择最适合您环境的部署方法：
+
+### Docker（推荐）
+```bash
+# 启动 Redis 和 Onetime Secret
+docker run -p 6379:6379 -d redis:bookworm
+docker run -p 3000:3000 -d \
+  -e REDIS_URL=redis://host.docker.internal:6379/0 \
+  -e SECRET="$(openssl rand -hex 32)" \
+  onetimesecret/onetimesecret:latest
+```
+
+访问 `http://localhost:3000`。
+
+### 手动安装
+适用于需要自定义配置的生产环境。
+
+请参阅我们的[安装和部署](./self-hosting/installation)指南以获取详细步骤。
+
+## 包含的功能
+
+您的自托管实例包括：
+
+- **Web 界面** - 用于创建和共享机密内容的全功能 UI
+- **REST API** - 用于集成的编程访问
+- **多语言支持** - 支持 12 种以上的语言
+- **自定义域名** - 使用您自己的域名和品牌
+
+
+## 系统要求
+
+**推荐配置：**
+- 2 个以上 CPU 核心
+- 2GB 以上内存
+- 10GB 以上磁盘空间
+- Redis 用于会话存储
+- Node.js 22+（用于开发）
+
+## 后续步骤
+
+1. **[入门指南](./self-hosting/getting-started)** - 分步设置指南
+2. **[安装和部署](./self-hosting/installation)** - 详细的部署选项
+3. **[配置参考](./self-hosting/configuration)** - 完整的设置文档
+
+---
+
+_准备好开始了吗？请遵循我们的[入门指南](./self-hosting/getting-started)。_

--- a/src/content/docs/zh-cn/self-hosting/installation.md
+++ b/src/content/docs/zh-cn/self-hosting/installation.md
@@ -1,0 +1,407 @@
+---
+title: 安装和部署
+description: Onetime Secret 生产部署的综合指南
+sidebar:
+  order: 3
+---
+
+本指南涵盖了自托管 Onetime Secret 实例的部署选项。
+
+## 部署选项
+
+### Docker 部署
+
+Docker 提供最可靠和便携的部署方法。
+
+#### 使用 Docker Compose
+
+对于完整的基础设施管理，请使用专用的 Docker Compose 仓库：
+
+**仓库**：https://github.com/onetimesecret/docker-compose/
+
+**快速设置：**
+```bash
+git clone https://github.com/onetimesecret/docker-compose.git
+cd docker-compose
+docker-compose up -d
+```
+
+**手动 Docker Compose 设置：**
+
+```yaml
+# docker-compose.yml
+version: '3.8'
+
+services:
+  onetime:
+    image: onetimesecret/onetimesecret:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - REDIS_URL=redis://redis:6379/0
+      - SECRET=${SECRET}
+      - HOST=${HOST:-localhost:3000}
+      - SSL=${SSL:-false}
+      - RACK_ENV=production
+    depends_on:
+      - redis
+    volumes:
+      - ./etc:/app/etc
+      - ./logs:/app/logs
+
+  redis:
+    image: redis:bookworm
+    volumes:
+      - redis_data:/data
+    command: redis-server --requirepass ${REDIS_PASSWORD}
+
+volumes:
+  redis_data:
+```
+
+**环境变量文件（.env）：**
+```bash
+SECRET=your-secure-32-character-hex-key
+REDIS_PASSWORD=your-redis-password
+HOST=your-domain.com
+SSL=true
+```
+
+### 手动安装
+
+适用于需要自定义配置或现有基础设施的环境。
+
+#### 安装依赖项
+
+**Ubuntu 22.04 LTS：**
+```bash
+# 更新系统
+sudo apt update && sudo apt upgrade -y
+
+# 安装 Ruby 和构建工具
+sudo apt install -y ruby ruby-dev build-essential git
+sudo gem install bundler
+
+# 安装 Redis
+sudo apt install -y redis-server
+sudo systemctl enable redis-server
+sudo systemctl start redis-server
+
+# 安装 Node.js（用于开发和构建前端资源）
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+sudo apt install -y nodejs
+sudo npm install -g pnpm@latest
+```
+
+**CentOS/RHEL 8：**
+```bash
+# 启用 PowerTools/CodeReady 仓库
+sudo dnf install -y dnf-plugins-core
+sudo dnf config-manager --set-enabled powertools
+
+# 安装 Ruby 和开发工具
+sudo dnf groupinstall -y "Development Tools"
+sudo dnf install -y ruby ruby-devel git
+sudo gem install bundler
+
+# 安装 Redis
+sudo dnf install -y redis
+sudo systemctl enable redis
+sudo systemctl start redis
+```
+
+#### 应用程序设置
+
+```bash
+# 创建应用程序用户
+sudo useradd -r -m -s /bin/bash onetime
+
+# 切换到应用程序用户
+sudo su - onetime
+
+# 克隆仓库
+git clone https://github.com/onetimesecret/onetimesecret.git
+cd onetimesecret
+
+# 安装依赖项
+bundle install --deployment --without development test
+
+# 复制并配置环境
+cp .env.example .env
+cp ./etc/config.example.yaml ./etc/config.yaml
+
+# 创建提交哈希以进行版本跟踪
+git rev-parse --short HEAD > .commit_hash.txt
+```
+
+## 反向代理配置
+
+这些配置示例可以帮助您入门，但您应该根据您的特定需求进行调整。
+
+### Nginx
+
+**基本配置：**
+
+```nginx
+# /etc/nginx/sites-available/onetime
+server {
+    listen 80;
+    server_name your-domain.com;
+    return 301 https://$server_name$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name your-domain.com;
+
+    # SSL 配置
+    ssl_certificate /path/to/your/cert.pem;
+    ssl_certificate_key /path/to/your/key.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512;
+
+    # 安全标头
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Frame-Options DENY always;
+    add_header X-Content-Type-Options nosniff always;
+
+    # 来自构建的前端的静态文件
+    location /dist/ {
+        root /app/public;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri $uri/ =404;
+    }
+
+    # API 请求到后端
+    location /api/ {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # 所有其他请求到后端
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # WebSocket 支持
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}
+```
+
+**启用站点：**
+```bash
+sudo ln -s /etc/nginx/sites-available/onetime /etc/nginx/sites-enabled/
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+### Caddy
+
+Caddy 提供自动 HTTPS 和更简单的配置：
+
+```nginx
+# /etc/caddy/Caddyfile
+your-domain.com {
+    # 处理来自构建的前端的静态文件
+    handle /dist/* {
+        root * /app/public
+        file_server
+    }
+
+    # API 请求到后端
+    handle /api/* {
+        reverse_proxy 127.0.0.1:3000
+    }
+
+    # 所有其他请求到后端（用于服务器渲染的页面）
+    handle {
+        reverse_proxy 127.0.0.1:3000
+    }
+}
+```
+
+### Apache
+
+```apache
+# /etc/apache2/sites-available/onetime.conf
+<VirtualHost *:80>
+    ServerName your-domain.com
+    Redirect permanent / https://your-domain.com/
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerName your-domain.com
+
+    # SSL 配置
+    SSLEngine on
+    SSLCertificateFile /path/to/your/cert.pem
+    SSLCertificateKeyFile /path/to/your/key.pem
+
+    # 安全标头
+    Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+    Header always set X-Frame-Options DENY
+    Header always set X-Content-Type-Options nosniff
+
+    # 来自构建的前端的静态文件
+    Alias /dist /app/public/dist
+    <Directory /app/public/dist>
+        Require all granted
+        ExpiresActive On
+        ExpiresDefault "access plus 1 year"
+    </Directory>
+
+    # API 和应用程序请求到后端
+    ProxyPreserveHost On
+    ProxyPass /dist !
+    ProxyPass / http://127.0.0.1:3000/
+    ProxyPassReverse / http://127.0.0.1:3000/
+</VirtualHost>
+```
+
+## SSL/TLS 配置
+
+### Let's Encrypt (Certbot)
+
+**安装 Certbot：**
+```bash
+# Ubuntu/Debian
+sudo apt install certbot python3-certbot-nginx
+
+# CentOS/RHEL
+sudo dnf install certbot python3-certbot-nginx
+```
+
+**生成证书：**
+```bash
+# 用于 Nginx
+sudo certbot --nginx -d your-domain.com
+
+# 用于 Apache
+sudo certbot --apache -d your-domain.com
+
+# 手动证书（如果使用自定义代理配置）
+sudo certbot certonly --webroot -w /var/www/html -d your-domain.com
+```
+
+**自动续期：**
+```bash
+# 添加到 crontab
+echo "0 12 * * * /usr/bin/certbot renew --quiet" | sudo tee -a /etc/crontab
+```
+
+### 自定义 SSL 证书
+
+放置您的证书并在代理配置中更新路径：
+
+```bash
+# 证书文件
+/etc/ssl/certs/your-domain.com.crt
+/etc/ssl/private/your-domain.com.key
+
+# 设置适当的权限
+sudo chmod 600 /etc/ssl/private/your-domain.com.key
+sudo chmod 644 /etc/ssl/certs/your-domain.com.crt
+```
+
+
+### Redis 配置
+
+**选项 1：仅内存（永不保存到磁盘以实现最大安全性）：**
+
+```properties
+# /etc/redis/redis.conf
+
+# 内存优化
+maxmemory 1gb
+maxmemory-policy allkeys-lru
+
+# 安全性 - 机密内容永不写入磁盘
+save ""  # 禁用所有自动保存
+appendonly no  # 禁用 AOF 日志
+
+# 安全性
+requirepass your_redis_password
+bind 127.0.0.1
+
+# 性能
+tcp-keepalive 60
+timeout 300
+```
+
+**选项 2：磁盘持久化（启用备份但将机密内容写入磁盘）：**
+
+```properties
+# /etc/redis/redis.conf
+
+# 内存优化
+maxmemory 1gb
+maxmemory-policy allkeys-lru
+
+# RDB 快照 - 创建 dump.rdb 文件
+save 900 1    # 如果在 900 秒内至少有 1 个键更改则保存
+save 300 10   # 如果在 300 秒内至少有 10 个键更改则保存
+save 60 10000 # 如果在 60 秒内至少有 10000 个键更改则保存
+
+# AOF 日志 - 创建 appendonly.aof 文件以进行时间点恢复
+appendonly yes
+appendfsync everysec  # 每秒同步到磁盘
+
+# 安全性
+requirepass your_redis_password
+bind 127.0.0.1
+
+# 性能
+tcp-keepalive 60
+timeout 300
+```
+
+**重要提示**：启用磁盘持久化后，机密内容将写入：
+- `dump.rdb` 文件（间隔快照）
+- `appendonly.aof` 文件（连续追加日志）
+
+根据您的安全性与备份需求进行选择。
+
+**重启 Redis：**
+```bash
+sudo systemctl restart redis
+```
+
+#### Redis 备份
+
+**Redis：**
+```bash
+#!/bin/bash
+# Redis 备份脚本
+BACKUP_DIR="/var/backups/onetime"
+DATE=$(date +%Y%m%d_%H%M%S)
+
+mkdir -p $BACKUP_DIR
+
+# 创建备份
+redis-cli -a "$REDIS_PASSWORD" --rdb $BACKUP_DIR/redis_$DATE.rdb
+
+# 清理旧备份
+find $BACKUP_DIR -name "redis_*.rdb" -mtime +7 -delete
+```
+
+## 后续步骤
+
+成功部署后：
+
+1. **[配置您的实例](./configuration)** 使用自定义设置
+2. **设置监控和警报** 用于生产运营
+3. **查看安全设置** 并启用额外保护
+4. **配置备份自动化** 并测试恢复程序
+5. **为您的组织设置自定义域名**
+
+您的 Onetime Secret 实例现在已准备好用于生产！


### PR DESCRIPTION
This commit adds complete self-hosting documentation translations to Chinese Simplified, increasing locale coverage from 85% to 100% (34/34 files).

Files added:
- self-hosting/index.md - Self-hosting overview
- self-hosting/getting-started.md - Quick setup guide
- self-hosting/installation.md - Detailed deployment options
- self-hosting/configuration.md - Complete configuration reference
- self-hosting/environment-variables.md - Environment variables reference

Translation quality:
- Uses proper Simplified Chinese characters (not Traditional)
- Follows existing zh-cn terminology and style
- Maintains proper spacing around English terms
- Uses Chinese punctuation throughout
- Technical accuracy preserved

This completes the Chinese Simplified locale to 100% coverage.