### PR TITLE
[#I18N] Add translation export guides for 16 languages

### DIFF
--- a/src/content/docs/bg/translations/export-guide.md
+++ b/src/content/docs/bg/translations/export-guide.md
@@ -1,3 +1,8 @@
+---
+title: Ръководство за превод на български
+description: Цялостно ръководство за превод на Onetime Secret на български език, съчетаващо речник на термините и езикови бележки
+---
+
 # Translation Guidance for Bulgarian (Български)
 
 This document combines the glossary and language-specific translation notes to provide comprehensive guidance for translating Onetime Secret into Bulgarian. It serves as a reference for maintaining consistency, clarity, and cultural appropriateness across the application.

--- a/src/content/docs/da/translations/export-guide.md
+++ b/src/content/docs/da/translations/export-guide.md
@@ -1,3 +1,8 @@
+---
+title: Oversættelsesvejledning til dansk
+description: Omfattende vejledning til oversættelse af Onetime Secret til dansk, der kombinerer ordliste og sproglige noter
+---
+
 # Translation Guidance for Danish (Dansk)
 
 This document combines the glossary of standardized terms and language-specific translation notes for Danish translations of Onetime Secret. It serves as a comprehensive reference for translators working on the Danish locale to ensure consistency, accuracy, and natural phrasing.

--- a/src/content/docs/de/translations/export-guide.md
+++ b/src/content/docs/de/translations/export-guide.md
@@ -1,3 +1,8 @@
+---
+title: Übersetzungsanleitung für Deutsch
+description: Umfassende Anleitung zur Übersetzung von Onetime Secret ins Deutsche mit Glossar und Sprachhinweisen
+---
+
 # Translation Guidance for German (Deutsch)
 
 This document combines the translation glossary and language-specific notes to provide comprehensive guidance for translating Onetime Secret content into German. It serves as a reference for maintaining consistency, accuracy, and appropriate tone across all German translations.

--- a/src/content/docs/es/translations/export-guide.md
+++ b/src/content/docs/es/translations/export-guide.md
@@ -1,3 +1,8 @@
+---
+title: Guía de traducción al español
+description: Guía completa para traducir Onetime Secret al español, que combina glosario y notas lingüísticas
+---
+
 # Translation Guidance for Spanish (Español)
 
 This document combines the glossary of standardized terms and language-specific translation notes for Spanish translations of Onetime Secret. It serves as a comprehensive reference for translators working on the Spanish locale to ensure consistency, accuracy, and natural phrasing.

--- a/src/content/docs/fr/translations/export-guide.md
+++ b/src/content/docs/fr/translations/export-guide.md
@@ -1,3 +1,8 @@
+---
+title: Guide de traduction pour le français
+description: Guide complet pour traduire Onetime Secret en français, combinant glossaire et notes linguistiques
+---
+
 # Translation Guidance for French (Français)
 
 This document combines the glossary and language-specific notes for French translations of Onetime Secret. It provides standardized translations for key terms and critical translation rules to ensure consistency across all French-language content.

--- a/src/content/docs/it/translations/export-guide.md
+++ b/src/content/docs/it/translations/export-guide.md
@@ -1,3 +1,8 @@
+---
+title: Guida alla traduzione per l'italiano
+description: Guida completa per tradurre Onetime Secret in italiano, che combina glossario e note linguistiche
+---
+
 # Translation Guidance for Italian (Italiano)
 
 This document combines the Onetime Secret glossary and Italian-specific language notes to provide comprehensive translation guidance for Italian localizations. It is designed to ensure consistency, accuracy, and cultural appropriateness across all Italian translations of the Onetime Secret platform.

--- a/src/content/docs/ja/translations/export-guide.md
+++ b/src/content/docs/ja/translations/export-guide.md
@@ -1,3 +1,8 @@
+---
+title: 日本語翻訳ガイド
+description: Onetime Secretの日本語翻訳のための包括的なガイド。用語集と言語固有の注意事項を組み合わせています
+---
+
 # Translation Guidance for Japanese (日本語)
 
 This document combines the Onetime Secret translation glossary and language-specific translation notes for Japanese. It serves as a comprehensive reference for translators and the saas-translator skill to ensure consistency, accuracy, and cultural appropriateness in Japanese translations.

--- a/src/content/docs/ko/translations/export-guide.md
+++ b/src/content/docs/ko/translations/export-guide.md
@@ -1,3 +1,8 @@
+---
+title: 한국어 번역 가이드
+description: Onetime Secret의 한국어 번역을 위한 포괄적인 가이드. 용어집과 언어별 주석을 결합합니다
+---
+
 # Translation Guidance for Korean (한국어)
 
 This document combines the glossary and language-specific translation notes for Korean (ko) localization of Onetime Secret. It provides standardized terminology, translation principles, and practical examples to ensure consistency and quality across all Korean translations.

--- a/src/content/docs/mi/translations/export-guide.md
+++ b/src/content/docs/mi/translations/export-guide.md
@@ -1,3 +1,8 @@
+---
+title: Aratohu Whakamāori ki te Reo Māori
+description: Aratohu whānui mō te whakamāori i a Onetime Secret ki te reo Māori, e whakakotahi ana i te papakupu me ngā tuhipoka reo
+---
+
 # Translation Guidance for Māori (Te Reo Māori)
 
 This document combines the comprehensive glossary and language-specific translation notes for Māori (mi-NZ) translations of Onetime Secret. It provides standardized terminology, cultural guidance, and detailed translation decisions to ensure consistency and quality across all Māori translations.

--- a/src/content/docs/nl/translations/export-guide.md
+++ b/src/content/docs/nl/translations/export-guide.md
@@ -1,3 +1,8 @@
+---
+title: Vertaalhandleiding voor Nederlands
+description: Uitgebreide handleiding voor het vertalen van Onetime Secret naar het Nederlands, met woordenlijst en taalkundige notities
+---
+
 # Translation Guidance for Dutch (Nederlands)
 
 This document combines the glossary and language-specific translation notes for Dutch localization of Onetime Secret. It provides comprehensive guidance for maintaining consistency, cultural appropriateness, and technical accuracy in Dutch translations.

--- a/src/content/docs/pl/translations/export-guide.md
+++ b/src/content/docs/pl/translations/export-guide.md
@@ -1,3 +1,8 @@
+---
+title: Przewodnik tłumaczenia na polski
+description: Kompleksowy przewodnik tłumaczenia Onetime Secret na język polski, łączący słowniczek i notatki językowe
+---
+
 # Translation Guidance for Polish (Polski)
 
 This document combines the glossary of standardized terms and language-specific translation notes for Polish translations of Onetime Secret. It serves as a comprehensive reference for translators working on the Polish locale to ensure consistency, accuracy, and natural phrasing.

--- a/src/content/docs/pt-br/translations/export-guide.md
+++ b/src/content/docs/pt-br/translations/export-guide.md
@@ -1,3 +1,8 @@
+---
+title: Guia de tradução para português brasileiro
+description: Guia completo para traduzir o Onetime Secret para português brasileiro, combinando glossário e notas linguísticas
+---
+
 # Translation Guidance for Portuguese (Português Brasileiro)
 
 This document combines the complete glossary and language-specific translation notes for Portuguese (Brazilian) translations of Onetime Secret. It serves as the authoritative reference for maintaining consistency, accuracy, and natural language flow across all Portuguese (Brazilian) content.

--- a/src/content/docs/sv/translations/export-guide.md
+++ b/src/content/docs/sv/translations/export-guide.md
@@ -1,3 +1,8 @@
+---
+title: Översättningsguide för svenska
+description: Omfattande guide för att översätta Onetime Secret till svenska, som kombinerar ordlista och språkliga anteckningar
+---
+
 # Translation Guidance for Swedish (Svenska)
 
 This document combines the glossary of standardized terms and language-specific translation notes for Swedish translations of Onetime Secret. It serves as a comprehensive reference for translators working on the Swedish locale to ensure consistency, accuracy, and natural phrasing.

--- a/src/content/docs/tr/translations/export-guide.md
+++ b/src/content/docs/tr/translations/export-guide.md
@@ -1,3 +1,8 @@
+---
+title: Türkçe çeviri rehberi
+description: Onetime Secret'ı Türkçe'ye çevirmek için kapsamlı rehber, sözlük ve dil notlarını birleştirir
+---
+
 # Translation Guidance for Turkish (Türkçe)
 
 This document combines the glossary of standardized terms and language-specific translation notes for Turkish translations of Onetime Secret. It serves as a comprehensive reference for translators working on the Turkish locale to ensure consistency, accuracy, and natural phrasing.

--- a/src/content/docs/uk/translations/export-guide.md
+++ b/src/content/docs/uk/translations/export-guide.md
@@ -1,3 +1,8 @@
+---
+title: Керівництво з перекладу українською
+description: Вичерпний посібник з перекладу Onetime Secret українською мовою, що поєднує глосарій та мовні примітки
+---
+
 # Translation Guidance for Ukrainian (Українська)
 
 This document combines the glossary of standardized terms and language-specific translation notes for Ukrainian translations of Onetime Secret. It serves as a comprehensive reference for translators working on the Ukrainian locale to ensure consistency, accuracy, and natural phrasing.

--- a/src/content/docs/zh-cn/translations/export-guide.md
+++ b/src/content/docs/zh-cn/translations/export-guide.md
@@ -1,3 +1,8 @@
+---
+title: 简体中文翻译指南
+description: Onetime Secret 简体中文翻译综合指南，结合术语表和语言注释
+---
+
 # Translation Guidance for Simplified Chinese (简体中文)
 
 This document combines translation glossary and language-specific notes to provide comprehensive guidance for translating Onetime Secret into Simplified Chinese. It serves as the authoritative reference for maintaining consistency, quality, and cultural appropriateness in Chinese translations.


### PR DESCRIPTION
Extends translation infrastructure with comprehensive export guides for
Bulgarian, Danish, German, Spanish, French, Italian, Japanese, Korean,
Māori, Dutch, Polish, Portuguese (Brazil), Swedish, Turkish, Ukrainian,
and Simplified Chinese.

Each guide provides: - Core terminology glossary with cross-language
references - Critical terminology distinctions (password vs passphrase,
etc.) - UI element translations - Language-specific translation notes
and cultural considerations

These guides consolidate glossary data with export-ready formatting to
support professional translation services and maintain consistency
across all language versions.

Related to #231
