### PR TITLE
Enable .well-known directory deployment to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,6 +89,7 @@ jobs:
         uses: actions/upload-pages-artifact@v4
         with:
           path: ./dist
+          include-hidden-files: true
 
       # Upload build artifact for workflow records (optional)
       - name: Upload build artifact


### PR DESCRIPTION
## What

Add `include-hidden-files: true` to the GitHub Pages artifact upload step to enable deployment of the `.well-known/` directory.

## Why

The `.well-known/agent-network.json` discovery manifest was not being deployed because the GitHub Pages artifact uploader excludes hidden files by default. This fix ensures the agent network manifest is accessible at `/.well-known/agent-network.json`.

## Details

- Enables deployment of `/.well-known/` directory (RFC 5785 standard location)
- Necessary for agent discovery and other `.well-known/` standards
- No performance or security impact

## Testing

After merge, verify:
```bash
curl https://docs.onetimesecret.com/.well-known/agent-network.json
```