### PR TITLE
Upgrade guide fixes and API i18n strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "generate:for-translators": "./bin/generate-for-translators all"
   },
   "dependencies": {
-    "@astrojs/check": "^0.9.8",
     "@astrojs/markdoc": "^0.15.11",
     "@astrojs/react": "^4.4.2",
     "@astrojs/starlight": "^0.37.7",
@@ -29,8 +28,6 @@
     "@astrojs/starlight-tailwind": "^4.0.2",
     "@astrojs/vue": "^5.1.4",
     "@tailwindcss/vite": "^4.2.1",
-    "@types/react": "^19.2.14",
-    "@types/react-dom": "^19.2.3",
     "accessible-astro-components": "^5.2.0",
     "astro": "^5.18.1",
     "devalue": "^5.6.4",
@@ -40,7 +37,12 @@
     "sharp": "^0.34.5",
     "sitemap": "9.0.1",
     "tailwindcss": "^4.2.1",
-    "typescript": "^5.9.3",
     "vue": "^3.5.30"
+  },
+  "devDependencies": {
+    "@astrojs/check": "^0.9.8",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "typescript": "^5.9.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@astrojs/check':
-        specifier: ^0.9.8
-        version: 0.9.8(prettier@3.8.1)(typescript@5.9.3)
       '@astrojs/markdoc':
         specifier: ^0.15.11
         version: 0.15.11(@types/react@19.2.14)(astro@5.18.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2))(react@19.2.4)
@@ -32,12 +29,6 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.2.1
         version: 4.2.1(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
-      '@types/react':
-        specifier: ^19.2.14
-        version: 19.2.14
-      '@types/react-dom':
-        specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.14)
       accessible-astro-components:
         specifier: ^5.2.0
         version: 5.2.0
@@ -65,12 +56,22 @@ importers:
       tailwindcss:
         specifier: ^4.2.1
         version: 4.2.1
-      typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
       vue:
         specifier: ^3.5.30
         version: 3.5.30(typescript@5.9.3)
+    devDependencies:
+      '@astrojs/check':
+        specifier: ^0.9.8
+        version: 0.9.8(prettier@3.8.1)(typescript@5.9.3)
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
 
 packages:
 

--- a/src/content/docs/en/pricing/compare-plans.md
+++ b/src/content/docs/en/pricing/compare-plans.md
@@ -26,6 +26,6 @@ For more information on account upgrades and pricing, please visit our [Pricing 
 ## Coming Soon
 
 * Team plans for multiple users (April 2026)
-* [Secretary Links](https://onetimesecretary.com) — secure collection links for receiving sensitive information from anyone, no account required
+* [Secretary Links](https://secretlinks.com) — secure collection links for receiving sensitive information from anyone, no account required
 * Inbound Secrets — a destination page for customers, clients, etc. to send secrets directly to a preconfigured list of recipients
 * Custom email from details with SPF and DKIM support

--- a/src/content/docs/en/self-hosting/upgrading-v0-24.md
+++ b/src/content/docs/en/self-hosting/upgrading-v0-24.md
@@ -11,7 +11,7 @@ For the full context on what changed and why, see the [v0.24.0 release notes](ht
 
 ## Before You Start
 
-**Coming from v0.22?** Complete the [v0.23 config migration](upgrading-v0-23) first. The v0.23 release converts config keys from symbol to string format, which v0.24 requires.
+**Coming from v0.22?** Complete the [v0.23 config migration](../upgrading-v0-23/) first. The v0.23 release converts config keys from symbol to string format, which v0.24 requires.
 
 1. **Back up your Redis data.** `redis-cli BGSAVE` or equivalent. Keep the RDB file somewhere safe.
 2. **Back up your configuration files.** `config.yaml`,`.env`.
@@ -45,7 +45,7 @@ Use this path if you don't need to preserve existing accounts or live secrets.
 ### 1. Pull the new version
 
 ```bash
-docker pull onetimesecret/onetimesecret:v0.24.0
+docker pull onetimesecret/onetimesecret:v0.24.6
 ```
 
 Or clone/checkout the v0.24.0 tag if running from source, then run the install script:
@@ -119,7 +119,7 @@ docker run -p 3000:3000 -d \
   -e SECRET="$(cat .ots_secret)" \
   -e HOST=localhost:3000 \
   -e SSL=false \
-  onetimesecret/onetimesecret:v0.24.0
+  onetimesecret/onetimesecret:v0.24.6
 ```
 
 **Docker Compose** (for persistent or multi-service deployments):
@@ -160,7 +160,7 @@ Even if you already backed up in the prerequisites. Make a timestamped copy righ
 ### 3. Pull the new version
 
 ```bash
-docker pull onetimesecret/onetimesecret:v0.24.0
+docker pull onetimesecret/onetimesecret:v0.24.6
 ```
 
 Or clone/checkout the v0.24.0 tag if running from source. Do not start it yet. Run the install script to update dependencies and re-derive child keys:
@@ -255,7 +255,7 @@ docker run -p 3000:3000 -d \
   -e SECRET="$YOUR_SECRET" \
   -e HOST=your-domain.com \
   -e SSL=true \
-  onetimesecret/onetimesecret:v0.24.0
+  onetimesecret/onetimesecret:v0.24.6
 ```
 
 **Docker Compose:**

--- a/src/content/docs/en/self-hosting/upgrading-v0-24.md
+++ b/src/content/docs/en/self-hosting/upgrading-v0-24.md
@@ -11,7 +11,7 @@ For the full context on what changed and why, see the [v0.24.0 release notes](ht
 
 ## Before You Start
 
-**Coming from v0.22?** Complete the [v0.23 config migration](../upgrading-v0-23/) first. The v0.23 release converts config keys from symbol to string format, which v0.24 requires.
+**Coming from v0.22?** Complete the [v0.23 config migration](upgrading-v0-23/) first. The v0.23 release converts config keys from symbol to string format, which v0.24 requires.
 
 1. **Back up your Redis data.** `redis-cli BGSAVE` or equivalent. Keep the RDB file somewhere safe.
 2. **Back up your configuration files.** `config.yaml`,`.env`.

--- a/src/content/docs/en/self-hosting/upgrading-v0-24.md
+++ b/src/content/docs/en/self-hosting/upgrading-v0-24.md
@@ -45,7 +45,7 @@ Use this path if you don't need to preserve existing accounts or live secrets.
 ### 1. Pull the new version
 
 ```bash
-docker pull onetimesecret/onetimesecret:v0.24.6
+docker pull onetimesecret/onetimesecret:v0.24.5
 ```
 
 Or clone/checkout the v0.24.0 tag if running from source, then run the install script:
@@ -119,7 +119,7 @@ docker run -p 3000:3000 -d \
   -e SECRET="$(cat .ots_secret)" \
   -e HOST=localhost:3000 \
   -e SSL=false \
-  onetimesecret/onetimesecret:v0.24.6
+  onetimesecret/onetimesecret:v0.24.5
 ```
 
 **Docker Compose** (for persistent or multi-service deployments):
@@ -160,7 +160,7 @@ Even if you already backed up in the prerequisites. Make a timestamped copy righ
 ### 3. Pull the new version
 
 ```bash
-docker pull onetimesecret/onetimesecret:v0.24.6
+docker pull onetimesecret/onetimesecret:v0.24.5
 ```
 
 Or clone/checkout the v0.24.0 tag if running from source. Do not start it yet. Run the install script to update dependencies and re-derive child keys:
@@ -255,7 +255,7 @@ docker run -p 3000:3000 -d \
   -e SECRET="$YOUR_SECRET" \
   -e HOST=your-domain.com \
   -e SSL=true \
-  onetimesecret/onetimesecret:v0.24.6
+  onetimesecret/onetimesecret:v0.24.5
 ```
 
 **Docker Compose:**

--- a/src/content/i18n/bg.json
+++ b/src/content/i18n/bg.json
@@ -62,7 +62,9 @@
     "glossary": "Речник",
     "qualityChecklist": "Контролен списък за качество",
     "upgradingToV024": "Надграждане до v0.24.0",
-    "upgradingToV023": "Надграждане до v0.23.0"
+    "upgradingToV023": "Надграждане до v0.23.0",
+    "apiExplorer": "API Изследовател",
+    "apiReference": "API Справка"
   },
   "skipLink.label": "Преминаване към съдържанието",
   "search.label": "Търсене",

--- a/src/content/i18n/da.json
+++ b/src/content/i18n/da.json
@@ -62,7 +62,9 @@
     "glossary": "Ordliste",
     "qualityChecklist": "Kvalitetskontrolliste",
     "upgradingToV024": "Opgradering til v0.24.0",
-    "upgradingToV023": "Opgradering til v0.23.0"
+    "upgradingToV023": "Opgradering til v0.23.0",
+    "apiExplorer": "API-udforsker",
+    "apiReference": "API-reference"
   },
   "skipLink.label": "Spring til indhold",
   "search.label": "Søg",

--- a/src/content/i18n/de.json
+++ b/src/content/i18n/de.json
@@ -61,7 +61,9 @@
     "glossary": "Glossar",
     "qualityChecklist": "Qualitätsprüfliste",
     "upgradingToV024": "Upgrade auf v0.24.0",
-    "upgradingToV023": "Upgrade auf v0.23.0"
+    "upgradingToV023": "Upgrade auf v0.23.0",
+    "apiExplorer": "API Explorer",
+    "apiReference": "API-Referenz"
   },
   "skipLink.label": "Zum Inhalt springen",
   "search.label": "Suche",

--- a/src/content/i18n/en.json
+++ b/src/content/i18n/en.json
@@ -60,7 +60,9 @@
     "translations": "Translations",
     "universalGuidance": "Universal Guidance",
     "styleGuide": "Style Guide",
-    "glossary": "Glossary"
+    "glossary": "Glossary",
+    "apiExplorer": "API Explorer",
+    "apiReference": "API Reference"
   },
   "skipLink.label": "Skip to content",
   "search.label": "Search",

--- a/src/content/i18n/es.json
+++ b/src/content/i18n/es.json
@@ -61,7 +61,9 @@
     "glossary": "Glosario",
     "qualityChecklist": "Lista de verificación de calidad",
     "upgradingToV024": "Actualización a v0.24.0",
-    "upgradingToV023": "Actualización a v0.23.0"
+    "upgradingToV023": "Actualización a v0.23.0",
+    "apiExplorer": "API Explorador",
+    "apiReference": "Referencia de API"
   },
   "skipLink.label": "Saltar al contenido",
   "search.label": "Buscar",

--- a/src/content/i18n/fr.json
+++ b/src/content/i18n/fr.json
@@ -61,7 +61,9 @@
     "glossary": "Glossaire",
     "qualityChecklist": "Liste de contrôle qualité",
     "upgradingToV024": "Mise à jour vers v0.24.0",
-    "upgradingToV023": "Mise à jour vers v0.23.0"
+    "upgradingToV023": "Mise à jour vers v0.23.0",
+    "apiExplorer": "API Explorateur",
+    "apiReference": "Référence API"
   },
   "skipLink.label": "Passer au contenu",
   "search.label": "Rechercher",

--- a/src/content/i18n/it.json
+++ b/src/content/i18n/it.json
@@ -61,7 +61,9 @@
     "glossary": "Glossario",
     "qualityChecklist": "Lista di controllo qualità",
     "upgradingToV024": "Aggiornamento a v0.24.0",
-    "upgradingToV023": "Aggiornamento a v0.23.0"
+    "upgradingToV023": "Aggiornamento a v0.23.0",
+    "apiExplorer": "API Esploratore",
+    "apiReference": "Riferimento API"
   },
   "skipLink.label": "Vai al contenuto",
   "search.label": "Cerca",

--- a/src/content/i18n/ja.json
+++ b/src/content/i18n/ja.json
@@ -62,7 +62,9 @@
     "glossary": "用語集",
     "qualityChecklist": "品質チェックリスト",
     "upgradingToV024": "v0.24.0へのアップグレード",
-    "upgradingToV023": "v0.23.0へのアップグレード"
+    "upgradingToV023": "v0.23.0へのアップグレード",
+    "apiExplorer": "API エクスプローラー",
+    "apiReference": "API リファレンス"
   },
   "skipLink.label": "コンテンツにスキップ",
   "search.label": "検索",

--- a/src/content/i18n/ko.json
+++ b/src/content/i18n/ko.json
@@ -62,7 +62,9 @@
     "glossary": "용어집",
     "qualityChecklist": "품질 체크리스트",
     "upgradingToV024": "v0.24.0으로 업그레이드",
-    "upgradingToV023": "v0.23.0으로 업그레이드"
+    "upgradingToV023": "v0.23.0으로 업그레이드",
+    "apiExplorer": "API 탐색기",
+    "apiReference": "API 레퍼런스"
   },
   "skipLink.label": "콘텐츠로 건너뛰기",
   "search.label": "검색",

--- a/src/content/i18n/mi.json
+++ b/src/content/i18n/mi.json
@@ -62,7 +62,9 @@
     "glossary": "Papakupu",
     "qualityChecklist": "Rārangi Tirotiro Kounga",
     "upgradingToV024": "Whakahou ki v0.24.0",
-    "upgradingToV023": "Whakahou ki v0.23.0"
+    "upgradingToV023": "Whakahou ki v0.23.0",
+    "apiExplorer": "API Tūhuranga",
+    "apiReference": "API Tohutoro"
   },
   "skipLink.label": "Peke ki te ihirangi",
   "search.label": "Rapu",

--- a/src/content/i18n/nl.json
+++ b/src/content/i18n/nl.json
@@ -62,7 +62,9 @@
     "glossary": "Woordenlijst",
     "qualityChecklist": "Kwaliteitscontrolelijst",
     "upgradingToV024": "Upgraden naar v0.24.0",
-    "upgradingToV023": "Upgraden naar v0.23.0"
+    "upgradingToV023": "Upgraden naar v0.23.0",
+    "apiExplorer": "API Verkenner",
+    "apiReference": "API-referentie"
   },
   "skipLink.label": "Ga naar inhoud",
   "search.label": "Zoeken",

--- a/src/content/i18n/pl.json
+++ b/src/content/i18n/pl.json
@@ -62,7 +62,9 @@
     "glossary": "Glosariusz",
     "qualityChecklist": "Lista kontroli jakości",
     "upgradingToV024": "Aktualizacja do v0.24.0",
-    "upgradingToV023": "Aktualizacja do v0.23.0"
+    "upgradingToV023": "Aktualizacja do v0.23.0",
+    "apiExplorer": "API Eksplorator",
+    "apiReference": "Dokumentacja API"
   },
   "skipLink.label": "Przejdź do treści",
   "search.label": "Wyszukaj",

--- a/src/content/i18n/pt-br.json
+++ b/src/content/i18n/pt-br.json
@@ -62,7 +62,9 @@
     "glossary": "Glossário",
     "qualityChecklist": "Lista de verificação de qualidade",
     "upgradingToV024": "Atualização para v0.24.0",
-    "upgradingToV023": "Atualização para v0.23.0"
+    "upgradingToV023": "Atualização para v0.23.0",
+    "apiExplorer": "API Explorador",
+    "apiReference": "Referência da API"
   },
   "skipLink.label": "Pular para o conteúdo",
   "search.label": "Buscar",

--- a/src/content/i18n/sv.json
+++ b/src/content/i18n/sv.json
@@ -62,7 +62,9 @@
     "glossary": "Ordlista",
     "qualityChecklist": "Kvalitetschecklista",
     "upgradingToV024": "Uppgradering till v0.24.0",
-    "upgradingToV023": "Uppgradering till v0.23.0"
+    "upgradingToV023": "Uppgradering till v0.23.0",
+    "apiExplorer": "API-utforskare",
+    "apiReference": "API-referens"
   },
   "skipLink.label": "Hoppa till innehåll",
   "search.label": "Sök",

--- a/src/content/i18n/tr.json
+++ b/src/content/i18n/tr.json
@@ -62,7 +62,9 @@
     "glossary": "Sözlük",
     "qualityChecklist": "Kalite Kontrol Listesi",
     "upgradingToV024": "v0.24.0'a Yükseltme",
-    "upgradingToV023": "v0.23.0'a Yükseltme"
+    "upgradingToV023": "v0.23.0'a Yükseltme",
+    "apiExplorer": "API Gezgini",
+    "apiReference": "API Referansı"
   },
   "skipLink.label": "İçeriğe atla",
   "search.label": "Ara",

--- a/src/content/i18n/uk.json
+++ b/src/content/i18n/uk.json
@@ -62,7 +62,9 @@
     "glossary": "Глосарій",
     "qualityChecklist": "Контрольний список якості",
     "upgradingToV024": "Оновлення до v0.24.0",
-    "upgradingToV023": "Оновлення до v0.23.0"
+    "upgradingToV023": "Оновлення до v0.23.0",
+    "apiExplorer": "API Оглядач",
+    "apiReference": "API Довідник"
   },
   "skipLink.label": "Перейти до вмісту",
   "search.label": "Пошук",

--- a/src/content/i18n/zh-cn.json
+++ b/src/content/i18n/zh-cn.json
@@ -62,7 +62,9 @@
     "glossary": "词汇表",
     "qualityChecklist": "质量检查清单",
     "upgradingToV024": "升级到 v0.24.0",
-    "upgradingToV023": "升级到 v0.23.0"
+    "upgradingToV023": "升级到 v0.23.0",
+    "apiExplorer": "API 探索器",
+    "apiReference": "API 参考"
   },
   "skipLink.label": "跳转到内容",
   "search.label": "搜索",


### PR DESCRIPTION
## Summary

- Fix broken v0.23 link and correct docker image tags in v0.24 upgrade guide
- Add `apiExplorer` and `apiReference` sidebar label translations to all 17 locale files, replacing previously hardcoded strings

## Test plan

- [ ] Verify v0.24 upgrade guide renders with correct links and docker tags
- [ ] Confirm build succeeds with new i18n keys