### PR TITLE
Update OneTimeSecret Docker image version to v0.25.5

### DIFF
--- a/src/content/docs/bg/self-hosting/index.md
+++ b/src/content/docs/bg/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.0
+  onetimesecret/onetimesecret:v0.25.5
 ```
 
 Достъп на `http://localhost:3000`.

--- a/src/content/docs/da/self-hosting/getting-started.md
+++ b/src/content/docs/da/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.0
+  onetimesecret/onetimesecret:v0.25.5
 ```
 
 ### 4. Få adgang til din instans

--- a/src/content/docs/da/self-hosting/index.md
+++ b/src/content/docs/da/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.0
+  onetimesecret/onetimesecret:v0.25.5
 ```
 
 Få adgang på `http://localhost:3000`.

--- a/src/content/docs/de/self-hosting/index.md
+++ b/src/content/docs/de/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.0
+  onetimesecret/onetimesecret:v0.25.5
 ```
 
 Erreichbar unter `http://localhost:3000`.

--- a/src/content/docs/en/self-hosting/getting-started.md
+++ b/src/content/docs/en/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.0
+  onetimesecret/onetimesecret:v0.25.5
 ```
 
 ### 4. Access Your Instance

--- a/src/content/docs/en/self-hosting/index.md
+++ b/src/content/docs/en/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.0
+  onetimesecret/onetimesecret:v0.25.5
 ```
 
 Access at `http://localhost:3000`.

--- a/src/content/docs/en/self-hosting/installation.md
+++ b/src/content/docs/en/self-hosting/installation.md
@@ -34,7 +34,7 @@ version: '3.8'
 
 services:
   onetime:
-    image: onetimesecret/onetimesecret:v0.25.0
+    image: onetimesecret/onetimesecret:v0.25.5
     ports:
       - "3000:3000"
     environment:

--- a/src/content/docs/es/self-hosting/index.md
+++ b/src/content/docs/es/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.0
+  onetimesecret/onetimesecret:v0.25.5
 ```
 
 Acceda en `http://localhost:3000`.

--- a/src/content/docs/fr/self-hosting/index.md
+++ b/src/content/docs/fr/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.0
+  onetimesecret/onetimesecret:v0.25.5
 ```
 
 Accessible à l'adresse `http://localhost:3000`.

--- a/src/content/docs/it/self-hosting/index.md
+++ b/src/content/docs/it/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.0
+  onetimesecret/onetimesecret:v0.25.5
 ```
 
 Accessibile all'indirizzo `http://localhost:3000`.

--- a/src/content/docs/ja/self-hosting/index.md
+++ b/src/content/docs/ja/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.0
+  onetimesecret/onetimesecret:v0.25.5
 ```
 
 `http://localhost:3000` でアクセスできます。

--- a/src/content/docs/ko/self-hosting/index.md
+++ b/src/content/docs/ko/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.0
+  onetimesecret/onetimesecret:v0.25.5
 ```
 
 `http://localhost:3000`에서 접속할 수 있습니다.

--- a/src/content/docs/mi/self-hosting/getting-started.md
+++ b/src/content/docs/mi/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.0
+  onetimesecret/onetimesecret:v0.25.5
 ```
 
 ### 4. Uru ki Tō Tauira

--- a/src/content/docs/mi/self-hosting/index.md
+++ b/src/content/docs/mi/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.0
+  onetimesecret/onetimesecret:v0.25.5
 ```
 
 Uru mai i `http://localhost:3000`.

--- a/src/content/docs/mi/self-hosting/installation.md
+++ b/src/content/docs/mi/self-hosting/installation.md
@@ -34,7 +34,7 @@ version: '3.8'
 
 services:
   onetime:
-    image: onetimesecret/onetimesecret:v0.25.0
+    image: onetimesecret/onetimesecret:v0.25.5
     ports:
       - "3000:3000"
     environment:

--- a/src/content/docs/nl/self-hosting/index.md
+++ b/src/content/docs/nl/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.0
+  onetimesecret/onetimesecret:v0.25.5
 ```
 
 Toegankelijk op `http://localhost:3000`.

--- a/src/content/docs/pl/self-hosting/index.md
+++ b/src/content/docs/pl/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.0
+  onetimesecret/onetimesecret:v0.25.5
 ```
 
 Dostęp pod adresem `http://localhost:3000`.

--- a/src/content/docs/pt-br/self-hosting/getting-started.md
+++ b/src/content/docs/pt-br/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.0
+  onetimesecret/onetimesecret:v0.25.5
 ```
 
 ### 4. Acessar Sua Instância

--- a/src/content/docs/pt-br/self-hosting/index.md
+++ b/src/content/docs/pt-br/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.0
+  onetimesecret/onetimesecret:v0.25.5
 ```
 
 Acesse em `http://localhost:3000`.

--- a/src/content/docs/sv/self-hosting/getting-started.md
+++ b/src/content/docs/sv/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.0
+  onetimesecret/onetimesecret:v0.25.5
 ```
 
 ### 4. Få åtkomst till din instans

--- a/src/content/docs/sv/self-hosting/index.md
+++ b/src/content/docs/sv/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.0
+  onetimesecret/onetimesecret:v0.25.5
 ```
 
 Åtkomst på `http://localhost:3000`.

--- a/src/content/docs/sv/self-hosting/installation.md
+++ b/src/content/docs/sv/self-hosting/installation.md
@@ -34,7 +34,7 @@ version: '3.8'
 
 services:
   onetime:
-    image: onetimesecret/onetimesecret:v0.25.0
+    image: onetimesecret/onetimesecret:v0.25.5
     ports:
       - "3000:3000"
     environment:

--- a/src/content/docs/tr/self-hosting/getting-started.md
+++ b/src/content/docs/tr/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.0
+  onetimesecret/onetimesecret:v0.25.5
 ```
 
 ### 4. Örneğinize Erişin

--- a/src/content/docs/tr/self-hosting/index.md
+++ b/src/content/docs/tr/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.0
+  onetimesecret/onetimesecret:v0.25.5
 ```
 
 `http://localhost:3000` adresinden erişin.

--- a/src/content/docs/tr/self-hosting/installation.md
+++ b/src/content/docs/tr/self-hosting/installation.md
@@ -34,7 +34,7 @@ version: '3.8'
 
 services:
   onetime:
-    image: onetimesecret/onetimesecret:v0.25.0
+    image: onetimesecret/onetimesecret:v0.25.5
     ports:
       - "3000:3000"
     environment:

--- a/src/content/docs/uk/self-hosting/getting-started.md
+++ b/src/content/docs/uk/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.0
+  onetimesecret/onetimesecret:v0.25.5
 ```
 
 ### 4. Отримайте доступ до свого екземпляра

--- a/src/content/docs/uk/self-hosting/index.md
+++ b/src/content/docs/uk/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.0
+  onetimesecret/onetimesecret:v0.25.5
 ```
 
 Доступ за адресою `http://localhost:3000`.

--- a/src/content/docs/uk/self-hosting/installation.md
+++ b/src/content/docs/uk/self-hosting/installation.md
@@ -34,7 +34,7 @@ version: '3.8'
 
 services:
   onetime:
-    image: onetimesecret/onetimesecret:v0.25.0
+    image: onetimesecret/onetimesecret:v0.25.5
     ports:
       - "3000:3000"
     environment:

--- a/src/content/docs/zh-cn/self-hosting/getting-started.md
+++ b/src/content/docs/zh-cn/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.0
+  onetimesecret/onetimesecret:v0.25.5
 ```
 
 ### 4. 访问您的实例

--- a/src/content/docs/zh-cn/self-hosting/index.md
+++ b/src/content/docs/zh-cn/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.0
+  onetimesecret/onetimesecret:v0.25.5
 ```
 
 访问 `http://localhost:3000`。

--- a/src/content/docs/zh-cn/self-hosting/installation.md
+++ b/src/content/docs/zh-cn/self-hosting/installation.md
@@ -34,7 +34,7 @@ version: '3.8'
 
 services:
   onetime:
-    image: onetimesecret/onetimesecret:v0.25.0
+    image: onetimesecret/onetimesecret:v0.25.5
     ports:
       - "3000:3000"
     environment:


### PR DESCRIPTION
## Summary
This PR updates the OneTimeSecret Docker image version from v0.25.0 to v0.25.5 across all self-hosting documentation files.

## Changes Made
- Updated Docker image tag `onetimesecret/onetimesecret:v0.25.0` to `onetimesecret/onetimesecret:v0.25.5` in all self-hosting documentation
- Changes applied consistently across all supported language translations:
  - English (en)
  - Bulgarian (bg)
  - Danish (da)
  - German (de)
  - Spanish (es)
  - French (fr)
  - Italian (it)
  - Japanese (ja)
  - Korean (ko)
  - Māori (mi)
  - Dutch (nl)
  - Polish (pl)
  - Portuguese (pt-br)
  - Swedish (sv)
  - Turkish (tr)
  - Ukrainian (uk)
  - Simplified Chinese (zh-cn)

## Documentation Files Updated
- `self-hosting/index.md` - Updated in all language versions
- `self-hosting/getting-started.md` - Updated in all language versions
- `self-hosting/installation.md` - Updated in English, Māori, Swedish, Turkish, and Simplified Chinese versions

This ensures users following the self-hosting documentation will deploy the latest stable version of OneTimeSecret.

https://claude.ai/code/session_01MKNgF2oBNG3Zr2Y3is1EBx