### PR TITLE
Update OneTimeSecret Docker image version to v0.25.8

### DIFF
--- a/src/content/docs/bg/self-hosting/index.md
+++ b/src/content/docs/bg/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.7
+  onetimesecret/onetimesecret:v0.25.8
 ```
 
 Достъп на `http://localhost:3000`.

--- a/src/content/docs/da/self-hosting/getting-started.md
+++ b/src/content/docs/da/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.7
+  onetimesecret/onetimesecret:v0.25.8
 ```
 
 ### 4. Få adgang til din instans

--- a/src/content/docs/da/self-hosting/index.md
+++ b/src/content/docs/da/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.7
+  onetimesecret/onetimesecret:v0.25.8
 ```
 
 Få adgang på `http://localhost:3000`.

--- a/src/content/docs/de/self-hosting/index.md
+++ b/src/content/docs/de/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.7
+  onetimesecret/onetimesecret:v0.25.8
 ```
 
 Erreichbar unter `http://localhost:3000`.

--- a/src/content/docs/en/self-hosting/getting-started.md
+++ b/src/content/docs/en/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.7
+  onetimesecret/onetimesecret:v0.25.8
 ```
 
 ### 4. Access Your Instance

--- a/src/content/docs/en/self-hosting/index.md
+++ b/src/content/docs/en/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.7
+  onetimesecret/onetimesecret:v0.25.8
 ```
 
 Access at `http://localhost:3000`.

--- a/src/content/docs/en/self-hosting/installation.md
+++ b/src/content/docs/en/self-hosting/installation.md
@@ -34,7 +34,7 @@ version: '3.8'
 
 services:
   onetime:
-    image: onetimesecret/onetimesecret:v0.25.7
+    image: onetimesecret/onetimesecret:v0.25.8
     ports:
       - "3000:3000"
     environment:

--- a/src/content/docs/es/self-hosting/index.md
+++ b/src/content/docs/es/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.7
+  onetimesecret/onetimesecret:v0.25.8
 ```
 
 Acceda en `http://localhost:3000`.

--- a/src/content/docs/fr/self-hosting/index.md
+++ b/src/content/docs/fr/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.7
+  onetimesecret/onetimesecret:v0.25.8
 ```
 
 Accessible à l'adresse `http://localhost:3000`.

--- a/src/content/docs/it/self-hosting/index.md
+++ b/src/content/docs/it/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.7
+  onetimesecret/onetimesecret:v0.25.8
 ```
 
 Accessibile all'indirizzo `http://localhost:3000`.

--- a/src/content/docs/ja/self-hosting/index.md
+++ b/src/content/docs/ja/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.7
+  onetimesecret/onetimesecret:v0.25.8
 ```
 
 `http://localhost:3000` でアクセスできます。

--- a/src/content/docs/ko/self-hosting/index.md
+++ b/src/content/docs/ko/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.7
+  onetimesecret/onetimesecret:v0.25.8
 ```
 
 `http://localhost:3000`에서 접속할 수 있습니다.

--- a/src/content/docs/mi/self-hosting/getting-started.md
+++ b/src/content/docs/mi/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.7
+  onetimesecret/onetimesecret:v0.25.8
 ```
 
 ### 4. Uru ki Tō Tauira

--- a/src/content/docs/mi/self-hosting/index.md
+++ b/src/content/docs/mi/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.7
+  onetimesecret/onetimesecret:v0.25.8
 ```
 
 Uru mai i `http://localhost:3000`.

--- a/src/content/docs/mi/self-hosting/installation.md
+++ b/src/content/docs/mi/self-hosting/installation.md
@@ -34,7 +34,7 @@ version: '3.8'
 
 services:
   onetime:
-    image: onetimesecret/onetimesecret:v0.25.7
+    image: onetimesecret/onetimesecret:v0.25.8
     ports:
       - "3000:3000"
     environment:

--- a/src/content/docs/nl/self-hosting/index.md
+++ b/src/content/docs/nl/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.7
+  onetimesecret/onetimesecret:v0.25.8
 ```
 
 Toegankelijk op `http://localhost:3000`.

--- a/src/content/docs/pl/self-hosting/index.md
+++ b/src/content/docs/pl/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.7
+  onetimesecret/onetimesecret:v0.25.8
 ```
 
 Dostęp pod adresem `http://localhost:3000`.

--- a/src/content/docs/pt-br/self-hosting/getting-started.md
+++ b/src/content/docs/pt-br/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.7
+  onetimesecret/onetimesecret:v0.25.8
 ```
 
 ### 4. Acessar Sua Instância

--- a/src/content/docs/pt-br/self-hosting/index.md
+++ b/src/content/docs/pt-br/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.7
+  onetimesecret/onetimesecret:v0.25.8
 ```
 
 Acesse em `http://localhost:3000`.

--- a/src/content/docs/sv/self-hosting/getting-started.md
+++ b/src/content/docs/sv/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.7
+  onetimesecret/onetimesecret:v0.25.8
 ```
 
 ### 4. Få åtkomst till din instans

--- a/src/content/docs/sv/self-hosting/index.md
+++ b/src/content/docs/sv/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.7
+  onetimesecret/onetimesecret:v0.25.8
 ```
 
 Åtkomst på `http://localhost:3000`.

--- a/src/content/docs/sv/self-hosting/installation.md
+++ b/src/content/docs/sv/self-hosting/installation.md
@@ -34,7 +34,7 @@ version: '3.8'
 
 services:
   onetime:
-    image: onetimesecret/onetimesecret:v0.25.7
+    image: onetimesecret/onetimesecret:v0.25.8
     ports:
       - "3000:3000"
     environment:

--- a/src/content/docs/tr/self-hosting/getting-started.md
+++ b/src/content/docs/tr/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.7
+  onetimesecret/onetimesecret:v0.25.8
 ```
 
 ### 4. Örneğinize Erişin

--- a/src/content/docs/tr/self-hosting/index.md
+++ b/src/content/docs/tr/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.7
+  onetimesecret/onetimesecret:v0.25.8
 ```
 
 `http://localhost:3000` adresinden erişin.

--- a/src/content/docs/tr/self-hosting/installation.md
+++ b/src/content/docs/tr/self-hosting/installation.md
@@ -34,7 +34,7 @@ version: '3.8'
 
 services:
   onetime:
-    image: onetimesecret/onetimesecret:v0.25.7
+    image: onetimesecret/onetimesecret:v0.25.8
     ports:
       - "3000:3000"
     environment:

--- a/src/content/docs/uk/self-hosting/getting-started.md
+++ b/src/content/docs/uk/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.7
+  onetimesecret/onetimesecret:v0.25.8
 ```
 
 ### 4. Отримайте доступ до свого екземпляра

--- a/src/content/docs/uk/self-hosting/index.md
+++ b/src/content/docs/uk/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.7
+  onetimesecret/onetimesecret:v0.25.8
 ```
 
 Доступ за адресою `http://localhost:3000`.

--- a/src/content/docs/uk/self-hosting/installation.md
+++ b/src/content/docs/uk/self-hosting/installation.md
@@ -34,7 +34,7 @@ version: '3.8'
 
 services:
   onetime:
-    image: onetimesecret/onetimesecret:v0.25.7
+    image: onetimesecret/onetimesecret:v0.25.8
     ports:
       - "3000:3000"
     environment:

--- a/src/content/docs/zh-cn/self-hosting/getting-started.md
+++ b/src/content/docs/zh-cn/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.7
+  onetimesecret/onetimesecret:v0.25.8
 ```
 
 ### 4. 访问您的实例

--- a/src/content/docs/zh-cn/self-hosting/index.md
+++ b/src/content/docs/zh-cn/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.7
+  onetimesecret/onetimesecret:v0.25.8
 ```
 
 访问 `http://localhost:3000`。

--- a/src/content/docs/zh-cn/self-hosting/installation.md
+++ b/src/content/docs/zh-cn/self-hosting/installation.md
@@ -34,7 +34,7 @@ version: '3.8'
 
 services:
   onetime:
-    image: onetimesecret/onetimesecret:v0.25.7
+    image: onetimesecret/onetimesecret:v0.25.8
     ports:
       - "3000:3000"
     environment:


### PR DESCRIPTION
## Summary
This PR updates the OneTimeSecret Docker image version from v0.25.7 to v0.25.8 across all self-hosting documentation files.

## Changes Made
- Updated Docker image tag `onetimesecret/onetimesecret:v0.25.7` to `onetimesecret/onetimesecret:v0.25.8` in all self-hosting documentation
- Changes applied consistently across 30+ documentation files covering:
  - Multiple languages (English, Bulgarian, Danish, German, Spanish, French, Italian, Japanese, Korean, Māori, Dutch, Polish, Portuguese (Brazil), Swedish, Turkish, Ukrainian, Simplified Chinese)
  - Multiple documentation sections (index.md, getting-started.md, installation.md)
  - Both Docker CLI commands and Docker Compose configurations

## Implementation Details
- All references to the old version have been systematically replaced with the new version
- The update maintains consistency across all language variants and documentation formats
- No functional changes to the documentation structure or content, only version number updates

https://claude.ai/code/session_01UYqgmykaaAHBXCzfTzhd7N