### PR TITLE
Update OneTimeSecret Docker image version to v0.25.10

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,8 +36,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          model: "claude-sonnet-4-6"
-          # model: "claude-opus-4-8"
+          model: "claude-opus-4-8"
+          # model: "claude-sonnet-4-6"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,7 +37,7 @@ jobs:
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           model: "claude-opus-4-8"
-          # model: "claude-sonnet-4-6"
+          fallback_model: "claude-sonnet-4-6"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,7 +36,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          model: "claude-sonnet-4-6"
+          # model: "claude-opus-4-8"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -57,7 +57,7 @@ jobs:
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           model: "claude-opus-4-8"
-          # model: "claude-sonnet-4-6"
+          fallback_model: "claude-sonnet-4-6"
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -56,7 +56,8 @@ jobs:
             actions: read
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          model: "claude-sonnet-4-6"
+          # model: "claude-opus-4-8"
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -56,8 +56,8 @@ jobs:
             actions: read
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          model: "claude-sonnet-4-6"
-          # model: "claude-opus-4-8"
+          model: "claude-opus-4-8"
+          # model: "claude-sonnet-4-6"
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"

--- a/src/content/docs/bg/self-hosting/index.md
+++ b/src/content/docs/bg/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.8
+  onetimesecret/onetimesecret:v0.25.10
 ```
 
 Достъп на `http://localhost:3000`.

--- a/src/content/docs/da/self-hosting/getting-started.md
+++ b/src/content/docs/da/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.8
+  onetimesecret/onetimesecret:v0.25.10
 ```
 
 ### 4. Få adgang til din instans

--- a/src/content/docs/da/self-hosting/index.md
+++ b/src/content/docs/da/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.8
+  onetimesecret/onetimesecret:v0.25.10
 ```
 
 Få adgang på `http://localhost:3000`.

--- a/src/content/docs/de/self-hosting/index.md
+++ b/src/content/docs/de/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.8
+  onetimesecret/onetimesecret:v0.25.10
 ```
 
 Erreichbar unter `http://localhost:3000`.

--- a/src/content/docs/en/self-hosting/getting-started.md
+++ b/src/content/docs/en/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.8
+  onetimesecret/onetimesecret:v0.25.10
 ```
 
 ### 4. Access Your Instance

--- a/src/content/docs/en/self-hosting/index.md
+++ b/src/content/docs/en/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.8
+  onetimesecret/onetimesecret:v0.25.10
 ```
 
 Access at `http://localhost:3000`.

--- a/src/content/docs/en/self-hosting/installation.md
+++ b/src/content/docs/en/self-hosting/installation.md
@@ -34,7 +34,7 @@ version: '3.8'
 
 services:
   onetime:
-    image: onetimesecret/onetimesecret:v0.25.8
+    image: onetimesecret/onetimesecret:v0.25.10
     ports:
       - "3000:3000"
     environment:

--- a/src/content/docs/es/self-hosting/index.md
+++ b/src/content/docs/es/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.8
+  onetimesecret/onetimesecret:v0.25.10
 ```
 
 Acceda en `http://localhost:3000`.

--- a/src/content/docs/fr/self-hosting/index.md
+++ b/src/content/docs/fr/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.8
+  onetimesecret/onetimesecret:v0.25.10
 ```
 
 Accessible à l'adresse `http://localhost:3000`.

--- a/src/content/docs/it/self-hosting/index.md
+++ b/src/content/docs/it/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.8
+  onetimesecret/onetimesecret:v0.25.10
 ```
 
 Accessibile all'indirizzo `http://localhost:3000`.

--- a/src/content/docs/ja/self-hosting/index.md
+++ b/src/content/docs/ja/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.8
+  onetimesecret/onetimesecret:v0.25.10
 ```
 
 `http://localhost:3000` でアクセスできます。

--- a/src/content/docs/ko/self-hosting/index.md
+++ b/src/content/docs/ko/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.8
+  onetimesecret/onetimesecret:v0.25.10
 ```
 
 `http://localhost:3000`에서 접속할 수 있습니다.

--- a/src/content/docs/mi/self-hosting/getting-started.md
+++ b/src/content/docs/mi/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.8
+  onetimesecret/onetimesecret:v0.25.10
 ```
 
 ### 4. Uru ki Tō Tauira

--- a/src/content/docs/mi/self-hosting/index.md
+++ b/src/content/docs/mi/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.8
+  onetimesecret/onetimesecret:v0.25.10
 ```
 
 Uru mai i `http://localhost:3000`.

--- a/src/content/docs/mi/self-hosting/installation.md
+++ b/src/content/docs/mi/self-hosting/installation.md
@@ -34,7 +34,7 @@ version: '3.8'
 
 services:
   onetime:
-    image: onetimesecret/onetimesecret:v0.25.8
+    image: onetimesecret/onetimesecret:v0.25.10
     ports:
       - "3000:3000"
     environment:

--- a/src/content/docs/nl/self-hosting/index.md
+++ b/src/content/docs/nl/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.8
+  onetimesecret/onetimesecret:v0.25.10
 ```
 
 Toegankelijk op `http://localhost:3000`.

--- a/src/content/docs/pl/self-hosting/index.md
+++ b/src/content/docs/pl/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.8
+  onetimesecret/onetimesecret:v0.25.10
 ```
 
 Dostęp pod adresem `http://localhost:3000`.

--- a/src/content/docs/pt-br/self-hosting/getting-started.md
+++ b/src/content/docs/pt-br/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.8
+  onetimesecret/onetimesecret:v0.25.10
 ```
 
 ### 4. Acessar Sua Instância

--- a/src/content/docs/pt-br/self-hosting/index.md
+++ b/src/content/docs/pt-br/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.8
+  onetimesecret/onetimesecret:v0.25.10
 ```
 
 Acesse em `http://localhost:3000`.

--- a/src/content/docs/sv/self-hosting/getting-started.md
+++ b/src/content/docs/sv/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.8
+  onetimesecret/onetimesecret:v0.25.10
 ```
 
 ### 4. Få åtkomst till din instans

--- a/src/content/docs/sv/self-hosting/index.md
+++ b/src/content/docs/sv/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.8
+  onetimesecret/onetimesecret:v0.25.10
 ```
 
 Åtkomst på `http://localhost:3000`.

--- a/src/content/docs/sv/self-hosting/installation.md
+++ b/src/content/docs/sv/self-hosting/installation.md
@@ -34,7 +34,7 @@ version: '3.8'
 
 services:
   onetime:
-    image: onetimesecret/onetimesecret:v0.25.8
+    image: onetimesecret/onetimesecret:v0.25.10
     ports:
       - "3000:3000"
     environment:

--- a/src/content/docs/tr/self-hosting/getting-started.md
+++ b/src/content/docs/tr/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.8
+  onetimesecret/onetimesecret:v0.25.10
 ```
 
 ### 4. Örneğinize Erişin

--- a/src/content/docs/tr/self-hosting/index.md
+++ b/src/content/docs/tr/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.8
+  onetimesecret/onetimesecret:v0.25.10
 ```
 
 `http://localhost:3000` adresinden erişin.

--- a/src/content/docs/tr/self-hosting/installation.md
+++ b/src/content/docs/tr/self-hosting/installation.md
@@ -34,7 +34,7 @@ version: '3.8'
 
 services:
   onetime:
-    image: onetimesecret/onetimesecret:v0.25.8
+    image: onetimesecret/onetimesecret:v0.25.10
     ports:
       - "3000:3000"
     environment:

--- a/src/content/docs/uk/self-hosting/getting-started.md
+++ b/src/content/docs/uk/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.8
+  onetimesecret/onetimesecret:v0.25.10
 ```
 
 ### 4. Отримайте доступ до свого екземпляра

--- a/src/content/docs/uk/self-hosting/index.md
+++ b/src/content/docs/uk/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.8
+  onetimesecret/onetimesecret:v0.25.10
 ```
 
 Доступ за адресою `http://localhost:3000`.

--- a/src/content/docs/uk/self-hosting/installation.md
+++ b/src/content/docs/uk/self-hosting/installation.md
@@ -34,7 +34,7 @@ version: '3.8'
 
 services:
   onetime:
-    image: onetimesecret/onetimesecret:v0.25.8
+    image: onetimesecret/onetimesecret:v0.25.10
     ports:
       - "3000:3000"
     environment:

--- a/src/content/docs/zh-cn/self-hosting/getting-started.md
+++ b/src/content/docs/zh-cn/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.8
+  onetimesecret/onetimesecret:v0.25.10
 ```
 
 ### 4. 访问您的实例

--- a/src/content/docs/zh-cn/self-hosting/index.md
+++ b/src/content/docs/zh-cn/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.8
+  onetimesecret/onetimesecret:v0.25.10
 ```
 
 访问 `http://localhost:3000`。

--- a/src/content/docs/zh-cn/self-hosting/installation.md
+++ b/src/content/docs/zh-cn/self-hosting/installation.md
@@ -34,7 +34,7 @@ version: '3.8'
 
 services:
   onetime:
-    image: onetimesecret/onetimesecret:v0.25.8
+    image: onetimesecret/onetimesecret:v0.25.10
     ports:
       - "3000:3000"
     environment:


### PR DESCRIPTION
## Summary
This PR updates the OneTimeSecret Docker image version from v0.25.8 to v0.25.10 across all self-hosting documentation files.

## Changes Made
- Updated Docker image tag `onetimesecret/onetimesecret:v0.25.8` to `onetimesecret/onetimesecret:v0.25.10` in all self-hosting documentation
- Changes applied consistently across all supported language translations:
  - Bulgarian (bg)
  - Danish (da)
  - German (de)
  - English (en)
  - Spanish (es)
  - French (fr)
  - Italian (it)
  - Japanese (ja)
  - Korean (ko)
  - Māori (mi)
  - Dutch (nl)
  - Polish (pl)
  - Portuguese (pt-br)
  - Swedish (sv)
  - Turkish (tr)
  - Ukrainian (uk)
  - Simplified Chinese (zh-cn)

## Documentation Files Updated
- `self-hosting/index.md` - Updated in all language versions
- `self-hosting/getting-started.md` - Updated in en, da, mi, pt-br, sv, tr, uk, zh-cn
- `self-hosting/installation.md` - Updated in en, mi, sv, tr, uk, zh-cn

This ensures all users following the self-hosting documentation will use the latest stable version of OneTimeSecret.

https://claude.ai/code/session_016EsvkBRH3tt5ScBzaJLZaA