### PR TITLE
Add BunnyCDN staging deploy for docs.onetimesecret.dev

### DIFF
--- a/.github/workflows/deploy-staging-bunny.yml
+++ b/.github/workflows/deploy-staging-bunny.yml
@@ -1,0 +1,109 @@
+# .github/workflows/deploy-staging-bunny.yml
+---
+name: Deploy Staging (BunnyCDN)
+
+# Publishes a staging/preview build to BunnyCDN at https://docs.onetimesecret.dev
+# so changes parked on integration branches can be previewed before they reach
+# main (which auto-deploys production to GitHub Pages at docs.onetimesecret.com).
+#
+# How it works: build the static site with the .dev canonical, mark it noindex,
+# upload dist/ to a Bunny Edge Storage zone, then purge the Pull Zone cache.
+#
+# One-time setup (Bunny dashboard + repo settings):
+#   1. Create an Edge Storage zone; note its name + region endpoint
+#      (e.g. storage.bunnycdn.com, or ny./la./uk. etc. for other regions).
+#   2. Create a Pull Zone linked to that storage zone; add the custom hostname
+#      docs.onetimesecret.dev and enable Bunny's free SSL.
+#   3. DNS: CNAME docs.onetimesecret.dev -> <your-pullzone>.b-cdn.net
+#   4. Repo -> Settings -> Secrets and variables -> Actions:
+#        Variables: BUNNY_STORAGE_ZONE, BUNNY_STORAGE_ENDPOINT
+#                   (optional) BUNNY_PULLZONE_ID
+#        Secrets:   BUNNY_STORAGE_PASSWORD   (storage zone read/write password)
+#                   (optional) BUNNY_API_KEY (account API key, for cache purge)
+
+on:
+  push:
+    branches:
+      - "integrate/**"
+      - "integration/**"
+  workflow_dispatch:
+
+# Single staging target; newest push wins, cancel any in-flight deploy.
+concurrency:
+  group: staging-bunny
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-staging:
+    name: Build and publish to BunnyCDN
+    runs-on: ubuntu-latest
+    # Skip cleanly until Bunny is configured, so unconfigured integration
+    # pushes don't fail. The job activates once BUNNY_STORAGE_ZONE is set.
+    if: ${{ vars.BUNNY_STORAGE_ZONE != '' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 10.30.3
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          cache: pnpm
+
+      - run: pnpm install
+
+      # Custom domain served at the root -> base path "/".
+      - name: Configure staging build env
+        run: echo "VITE_BASE_URL=/" >> .env.production
+
+      - name: Build (canonical = docs.onetimesecret.dev)
+        run: pnpm run build
+        env:
+          SITE_URL: https://docs.onetimesecret.dev
+
+      # Staging is a public mirror: keep it out of search indexes.
+      - name: Mark build as noindex
+        run: |
+          printf 'User-agent: *\nDisallow: /\n' > dist/robots.txt
+
+      - name: Upload dist/ to Bunny Edge Storage
+        env:
+          STORAGE_ZONE: ${{ vars.BUNNY_STORAGE_ZONE }}
+          STORAGE_ENDPOINT: ${{ vars.BUNNY_STORAGE_ENDPOINT }}
+          STORAGE_PASSWORD: ${{ secrets.BUNNY_STORAGE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [ -z "${STORAGE_ENDPOINT}" ] || [ -z "${STORAGE_PASSWORD}" ]; then
+            echo "::error::BUNNY_STORAGE_ENDPOINT (variable) and BUNNY_STORAGE_PASSWORD (secret) are required (see workflow header)."
+            exit 1
+          fi
+          base="https://${STORAGE_ENDPOINT}/${STORAGE_ZONE}"
+          cd dist
+          # PUT each file in parallel, preserving its relative path. Existing
+          # files are overwritten; the Pull Zone infers MIME from the extension.
+          # (Stale files from deleted pages persist in the zone -- harmless for
+          # staging; clear the zone in the Bunny dashboard for a clean rebuild.)
+          find . -type f -printf '%P\n' | xargs -P 8 -I{} \
+            curl -fsS --retry 3 -X PUT \
+              -H "AccessKey: ${STORAGE_PASSWORD}" \
+              --data-binary "@{}" \
+              "${base}/{}"
+          echo "Uploaded $(find . -type f | wc -l) files to ${STORAGE_ZONE}."
+
+      - name: Purge Pull Zone cache
+        if: ${{ vars.BUNNY_PULLZONE_ID != '' }}
+        env:
+          PULLZONE_ID: ${{ vars.BUNNY_PULLZONE_ID }}
+          BUNNY_API_KEY: ${{ secrets.BUNNY_API_KEY }}
+        run: |
+          set -euo pipefail
+          curl -fsS --retry 3 -X POST \
+            -H "AccessKey: ${BUNNY_API_KEY}" \
+            "https://api.bunny.net/pullzone/${PULLZONE_ID}/purgeCache"
+          echo "Purged Pull Zone ${PULLZONE_ID}."

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,7 +5,10 @@ import { createViteConfig, createAllowedHosts } from "./config/vite.mjs";
 import { createRedirectsConfig } from "./config/redirects.mjs";
 
 export default defineConfig({
-  site: "https://docs.onetimesecret.com",
+  // Canonical site URL. Defaults to production; the staging deploy overrides
+  // it via SITE_URL (e.g. https://docs.onetimesecret.dev) so canonicals,
+  // sitemap, and absolute links match the domain being served.
+  site: process.env.SITE_URL || "https://docs.onetimesecret.com",
   redirects: createRedirectsConfig(),
   integrations: createIntegrations(),
   vite: createViteConfig(),


### PR DESCRIPTION
Staging/preview deploy so changes parked on integration branches can be previewed before reaching main (production -> GitHub Pages, .com).

- astro.config.mjs: parameterize `site` via SITE_URL (defaults to production .com) so the staging build emits .dev canonicals, sitemap, and absolute URLs.
- .github/workflows/deploy-staging-bunny.yml: build with SITE_URL=.dev, force a noindex robots.txt (public preview shouldn't be indexed), upload dist/ to a Bunny Edge Storage zone, and purge the Pull Zone cache. Triggers on push to integrate/** and integration/** plus manual dispatch.

The job is gated on `vars.BUNNY_STORAGE_ZONE` so it skips cleanly until the Bunny storage zone, endpoint, and password are configured in repo settings.

DRAFT: uses a self-contained curl uploader; to be reconciled with the established BunnyCDN workflow from the main site repo.


Claude-Session: https://claude.ai/code/session_01Y68AmzXBGia4FpfBJQLfeq