### PR TITLE
Add GitHub Actions workflows for CI and BunnyCDN deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+# .github/workflows/ci.yml
+#
+# Build check for pull requests. Ensures the Astro site compiles before merge.
+---
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+      - "integration/*"
+      - "integrate/*"
+      - "feature/*"
+      - "fix/*"
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 10.30.3
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          cache: pnpm
+
+      - run: pnpm install
+
+      - name: Build
+        run: pnpm run build

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,117 @@
+# .github/workflows/deploy-production.yml
+#
+# Publishes the docs site from `main` to BunnyCDN at
+# https://docs.onetimesecret.com (production).
+#
+# Uses a GitHub Environment ("production") so the same secret names work for
+# both staging and production with different values per environment —
+# mirroring the proven pattern in onetimesecret.com.
+#
+# Required secrets/variables (scoped to the "production" environment):
+#
+#   Secrets:
+#     STORAGE_NAME            - Bunny Edge Storage zone name
+#     STORAGE_DESTINATION     - Directory within the storage zone (empty for root)
+#     STORAGE_PASSWORD_RW     - Storage zone read/write password
+#     STORAGE_KEY             - Storage zone API key (for uploads)
+#     PULL_ZONE_ID            - Bunny Pull Zone ID
+#     BUNNY_API_KEY           - Bunny account API key (for cache purge)
+#
+#   Variables (environment-level):
+#     VITE_BASE_URL           - Base URL path (typically "/")
+---
+name: (production) Build and Deploy to BunnyCDN
+
+concurrency:
+  group: ${{ github.workflow }}-production
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    concurrency: production
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10.30.3
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build site
+        run: pnpm run build
+        env:
+          SITE_URL: https://docs.onetimesecret.com
+
+      - name: Upload dist/ to Bunny Edge Storage
+        env:
+          STORAGE_ZONE: ${{ secrets.STORAGE_NAME }}
+          STORAGE_ENDPOINT: ${{ secrets.STORAGE_DESTINATION }}
+          STORAGE_PASSWORD: ${{ secrets.STORAGE_PASSWORD_RW }}
+        run: |
+          set -euo pipefail
+          if [ -z "${STORAGE_ENDPOINT}" ] || [ -z "${STORAGE_PASSWORD}" ]; then
+            echo "::error::STORAGE_DESTINATION and STORAGE_PASSWORD_RW secrets must be configured in the production environment."
+            exit 1
+          fi
+          base="https://${STORAGE_ENDPOINT}/${STORAGE_ZONE}"
+          cd dist
+          find . -type f -printf '%P\n' | xargs -P 8 -I{} \
+            curl -fsS --retry 3 -X PUT \
+              -H "AccessKey: ${STORAGE_PASSWORD}" \
+              --data-binary "@{}" \
+              "${base}/{}"
+          echo "Uploaded $(find . -type f | wc -l) files to ${STORAGE_ZONE}."
+
+      - name: Wait for storage replication
+        run: |
+          echo "Waiting 10 seconds for BunnyCDN storage replication..."
+          sleep 10
+
+      - name: Purge Pull Zone cache
+        env:
+          PULLZONE_ID: ${{ secrets.PULL_ZONE_ID }}
+          BUNNY_API_KEY: ${{ secrets.BUNNY_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PULLZONE_ID}" ] || [ -z "${BUNNY_API_KEY}" ]; then
+            echo "::warning::PULL_ZONE_ID or BUNNY_API_KEY not set — skipping cache purge."
+            exit 0
+          fi
+          echo "Purging BunnyCDN pull zone cache..."
+          response=$(curl -s -w "\n%{http_code}" --retry 3 -X POST \
+            "https://api.bunny.net/pullzone/${PULLZONE_ID}/purgeCache" \
+            -H "AccessKey: ${BUNNY_API_KEY}" \
+            -H "Content-Type: application/json")
+
+          http_code=$(echo "$response" | tail -n1)
+          body=$(echo "$response" | sed '$d')
+
+          if [[ "$http_code" -ge 200 && "$http_code" -lt 300 ]]; then
+            echo "Cache purge completed successfully (HTTP $http_code)"
+          else
+            echo "Cache purge failed with HTTP $http_code"
+            echo "Response: $body"
+            exit 1
+          fi

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,120 @@
+# .github/workflows/deploy-staging.yml
+#
+# Publishes the docs site from `develop` to BunnyCDN at
+# https://docs.onetimesecret.dev (staging).
+#
+# Uses a GitHub Environment ("staging") so the same secret names work for
+# both staging and production with different values per environment —
+# mirroring the proven pattern in onetimesecret.com.
+#
+# Required secrets/variables (scoped to the "staging" environment):
+#
+#   Secrets:
+#     STORAGE_NAME            - Bunny Edge Storage zone name
+#     STORAGE_DESTINATION     - Directory within the storage zone (empty for root)
+#     STORAGE_PASSWORD_RW     - Storage zone read/write password
+#     STORAGE_KEY             - Storage zone API key (for uploads)
+#     PULL_ZONE_ID            - Bunny Pull Zone ID
+#     BUNNY_API_KEY           - Bunny account API key (for cache purge)
+#
+#   Variables (environment-level):
+#     VITE_BASE_URL           - Base URL path (typically "/")
+---
+name: (staging) Build and Deploy to BunnyCDN
+
+concurrency:
+  group: ${{ github.workflow }}-staging
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment: staging
+    concurrency: staging
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10.30.3
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build site
+        run: pnpm run build
+        env:
+          SITE_URL: https://docs.onetimesecret.dev
+
+      - name: Mark build as noindex
+        run: printf 'User-agent: *\nDisallow: /\n' > dist/robots.txt
+
+      - name: Upload dist/ to Bunny Edge Storage
+        env:
+          STORAGE_ZONE: ${{ secrets.STORAGE_NAME }}
+          STORAGE_ENDPOINT: ${{ secrets.STORAGE_DESTINATION }}
+          STORAGE_PASSWORD: ${{ secrets.STORAGE_PASSWORD_RW }}
+        run: |
+          set -euo pipefail
+          if [ -z "${STORAGE_ENDPOINT}" ] || [ -z "${STORAGE_PASSWORD}" ]; then
+            echo "::error::STORAGE_DESTINATION and STORAGE_PASSWORD_RW secrets must be configured in the staging environment."
+            exit 1
+          fi
+          base="https://${STORAGE_ENDPOINT}/${STORAGE_ZONE}"
+          cd dist
+          find . -type f -printf '%P\n' | xargs -P 8 -I{} \
+            curl -fsS --retry 3 -X PUT \
+              -H "AccessKey: ${STORAGE_PASSWORD}" \
+              --data-binary "@{}" \
+              "${base}/{}"
+          echo "Uploaded $(find . -type f | wc -l) files to ${STORAGE_ZONE}."
+
+      - name: Wait for storage replication
+        run: |
+          echo "Waiting 10 seconds for BunnyCDN storage replication..."
+          sleep 10
+
+      - name: Purge Pull Zone cache
+        env:
+          PULLZONE_ID: ${{ secrets.PULL_ZONE_ID }}
+          BUNNY_API_KEY: ${{ secrets.BUNNY_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PULLZONE_ID}" ] || [ -z "${BUNNY_API_KEY}" ]; then
+            echo "::warning::PULL_ZONE_ID or BUNNY_API_KEY not set — skipping cache purge."
+            exit 0
+          fi
+          echo "Purging BunnyCDN pull zone cache..."
+          response=$(curl -s -w "\n%{http_code}" --retry 3 -X POST \
+            "https://api.bunny.net/pullzone/${PULLZONE_ID}/purgeCache" \
+            -H "AccessKey: ${BUNNY_API_KEY}" \
+            -H "Content-Type: application/json")
+
+          http_code=$(echo "$response" | tail -n1)
+          body=$(echo "$response" | sed '$d')
+
+          if [[ "$http_code" -ge 200 && "$http_code" -lt 300 ]]; then
+            echo "Cache purge completed successfully (HTTP $http_code)"
+          else
+            echo "Cache purge failed with HTTP $http_code"
+            echo "Response: $body"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
This PR introduces three GitHub Actions workflows to automate continuous integration and deployment of the documentation site to BunnyCDN for both staging and production environments.

## Key Changes

- **CI Workflow (`ci.yml`)**: Automated build verification on pull requests to `main`, `develop`, and feature branches. Ensures the Astro site compiles successfully before merging.

- **Staging Deployment (`deploy-staging.yml`)**: Automatically builds and deploys the docs site from the `develop` branch to BunnyCDN staging at `https://docs.onetimesecret.dev`. Includes:
  - Build with staging URL configuration
  - Upload to Bunny Edge Storage with parallel transfers (8 concurrent)
  - Automatic cache purge after deployment
  - `robots.txt` marked as `noindex` for staging environment

- **Production Deployment (`deploy-production.yml`)**: Automatically builds and deploys the docs site from the `main` branch to BunnyCDN production at `https://docs.onetimesecret.com`. Mirrors the staging workflow with production-specific configuration.

## Implementation Details

- Both deployment workflows use GitHub Environments (`staging` and `production`) to manage environment-specific secrets and variables, allowing the same secret names with different values per environment
- Deployments include a 10-second wait for BunnyCDN storage replication before cache purge
- Cache purge gracefully skips if API credentials are not configured (warning only)
- Concurrent workflow runs are prevented with concurrency groups to avoid race conditions
- All workflows use Node.js 22.x and pnpm 10.30.3 for consistency

https://claude.ai/code/session_01GW99tdpBnHLPkbG7bD5cS8