### PR TITLE
Add staging banner and watermark to documentation site

### DIFF
--- a/config/domains.mjs
+++ b/config/domains.mjs
@@ -1,0 +1,74 @@
+// config/domains.mjs
+// Central domain configuration for canonical URLs and staging detection.
+//
+// This mirrors the company site's `config/domains.ts` so the documentation
+// site marks its staging environment the same way the main onetimesecret.dev
+// site does (a top banner + a diagonal "STAGING" watermark). Keeping the
+// hostname list and helper identical across properties means the two sites
+// stay in sync if a new staging/dev domain is ever added.
+
+/**
+ * The canonical production domain for the documentation site. Used for the
+ * "Go to live docs" link in the staging banner so visitors can jump from the
+ * staging deploy to the real docs.
+ */
+export const CANONICAL_ORIGIN = "https://docs.onetimesecret.com";
+
+/**
+ * Hostnames that indicate a staging/development environment. The banner and
+ * watermark are shown on any hostname that exactly matches one of these or is
+ * a subdomain of it (e.g. `docs.onetimesecret.dev`).
+ */
+export const STAGING_HOSTNAMES = [
+  "onetimesecret.dev", // Staging deployment (docs.onetimesecret.dev)
+  "onetime.dev", // Local development convenience domain
+];
+
+/**
+ * Check if a hostname is a staging/development environment.
+ *
+ * Uses strict matching (exact match or subdomain) to prevent spoofing where an
+ * attacker could register e.g. `onetimesecret.dev.attacker.com`.
+ *
+ * @param {string | undefined | null} hostname
+ * @returns {boolean}
+ */
+export function isStagingHostname(hostname) {
+  if (!hostname) return false;
+  return STAGING_HOSTNAMES.some(
+    (staging) => hostname === staging || hostname.endsWith(`.${staging}`),
+  );
+}
+
+/**
+ * Decide at build time whether this is a staging build.
+ *
+ * The staging deploy sets `SITE_URL` to the .dev domain (see
+ * `.github/workflows/deploy-staging.yml`), which also drives canonical URLs
+ * and the sitemap. Because staging is a separate build from production we can
+ * resolve this once at build time — the banner is then baked into the static
+ * HTML with no client-side JavaScript, no layout shift, and no flash.
+ *
+ * The `STAGING_BANNER` environment variable provides an explicit override that
+ * takes precedence over `SITE_URL` detection:
+ *   - `STAGING_BANNER=true` (or `1`)  -> force the banner/watermark on
+ *   - `STAGING_BANNER=false` (or `0`) -> force them off
+ * This is handy for previewing the banner locally (`STAGING_BANNER=true
+ * pnpm dev`) or disabling it on a one-off staging build.
+ *
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {boolean}
+ */
+export function isStagingBuild(env = process.env) {
+  const flag = env.STAGING_BANNER;
+  if (flag === "true" || flag === "1") return true;
+  if (flag === "false" || flag === "0") return false;
+
+  const siteUrl = env.SITE_URL;
+  if (!siteUrl) return false;
+  try {
+    return isStagingHostname(new URL(siteUrl).hostname);
+  } catch {
+    return false;
+  }
+}

--- a/config/starlight.mjs
+++ b/config/starlight.mjs
@@ -1,6 +1,14 @@
 // docs.onetimesecret.com/starlight/config/starlight.mjs
 import { i18nConfig } from "./i18n.mjs";
 import { sidebar } from "./sidebar.mjs";
+import { isStagingBuild } from "./domains.mjs";
+
+// Staging builds (docs.onetimesecret.dev) get a top warning banner and a
+// diagonal "STAGING" watermark, mirroring the company site. Detection is done
+// once at build time from SITE_URL (see config/domains.mjs), so the markers
+// are baked into the static HTML — no client-side JS, no layout shift. On
+// production builds nothing below is wired up, so the output is untouched.
+const staging = isStagingBuild();
 
 /**
  * Starlight configuration object
@@ -26,6 +34,10 @@ export const starlightConfig = {
   components: {
     Header: "./src/components/starlight/Header.astro",
     SiteTitle: "./src/components/starlight/SiteTitle.astro",
+    // Staging only: wrap PageFrame to mount the staging banner + watermark.
+    ...(staging
+      ? { PageFrame: "./src/components/starlight/PageFrame.astro" }
+      : {}),
   },
   social: [
     {
@@ -43,6 +55,8 @@ export const starlightConfig = {
     "./src/styles/tailwind.css",
     "./src/fonts/font-face.css",
     "./src/styles/theme-overrides.css",
+    // Staging only: offsets Starlight's fixed header/sidebars for the banner.
+    ...(staging ? ["./src/styles/staging.css"] : []),
   ],
   defaultLocale: i18nConfig.defaultLocale,
   locales: i18nConfig.locales,

--- a/src/components/starlight/PageFrame.astro
+++ b/src/components/starlight/PageFrame.astro
@@ -1,0 +1,32 @@
+---
+// src/components/starlight/PageFrame.astro
+//
+// Override of Starlight's PageFrame that mounts the staging banner and the
+// diagonal "STAGING" watermark above the default page layout.
+//
+// This is registered as the PageFrame override ONLY on staging builds (see
+// config/starlight.mjs). On production the override is never wired up, so this
+// file is not loaded and the layout is identical to stock Starlight.
+//
+// We wrap — rather than reimplement — the default PageFrame so we inherit all
+// of Starlight's layout behaviour (header/sidebar/main placement, mobile menu
+// toggle, etc.) and only add our two fixed-position overlays. The default
+// component reads everything it needs from `Astro.locals.starlightRoute`, so
+// there are no props to thread through; we just forward the named slots.
+//
+// The fixed banner/watermark would otherwise sit on top of Starlight's fixed
+// header and sidebars, so `src/styles/staging.css` offsets those elements by
+// the banner height (`--ots-staging-banner-h`). That stylesheet is likewise
+// only loaded on staging builds.
+import Default from "@astrojs/starlight/components/PageFrame.astro";
+import StagingBanner from "./StagingBanner.astro";
+import StagingWatermark from "./StagingWatermark.astro";
+---
+
+<StagingBanner />
+<StagingWatermark />
+<Default>
+  <slot name="header" slot="header" />
+  <slot name="sidebar" slot="sidebar" />
+  <slot />
+</Default>

--- a/src/components/starlight/StagingBanner.astro
+++ b/src/components/starlight/StagingBanner.astro
@@ -1,0 +1,175 @@
+---
+// src/components/starlight/StagingBanner.astro
+//
+// Staging environment banner for the documentation site.
+//
+// Renders a slim warning strip pinned to the very top of the viewport so it is
+// obvious when someone is reading the staging docs (docs.onetimesecret.dev)
+// rather than the live site. This is the docs-site counterpart to the company
+// site's `StagingBanner.vue`, adapted for Starlight:
+//
+//   - It is an Astro component (no client-side JS / hydration), so the banner
+//     is part of the static HTML. Combined with build-time detection in
+//     `config/starlight.mjs`, that means zero layout shift and no flash.
+//   - Dark mode follows Starlight's `:root[data-theme='dark']` toggle rather
+//     than Tailwind's `dark:` variant (Starlight does not use the `.dark`
+//     class), so the strip recolours with the on-site theme switcher.
+//   - The fixed height is exposed to the layout as `--ots-staging-banner-h`
+//     (see `src/styles/staging.css`), which offsets Starlight's fixed header
+//     and sidebars so nothing is hidden behind the strip.
+//
+// i18n: copy comes from the Starlight `staging.*` keys when available, with an
+// English fallback so the component also works outside a Starlight page.
+
+import { CANONICAL_ORIGIN } from "../../../config/domains.mjs";
+
+const t = Astro.locals?.t;
+const warning = t
+  ? t("staging.bannerWarning")
+  : "You're viewing the staging documentation site";
+const description = t
+  ? t("staging.bannerDescription")
+  : "Content here is for testing and may differ from the live docs.";
+const goToProduction = t ? t("staging.goToProduction") : "Go to live docs";
+
+// Point at the same path on production so visitors land on the page they were
+// already reading, just on the live site.
+const productionHref = new URL(Astro.url.pathname, CANONICAL_ORIGIN).href;
+---
+
+<div class="ots-staging-banner print:hidden" aria-label={warning}>
+  <div class="ots-staging-banner__inner">
+    <svg
+      class="ots-staging-banner__icon"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      aria-hidden="true"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+      ></path>
+    </svg>
+    <p class="ots-staging-banner__text">
+      <span class="ots-staging-banner__warning">{warning}</span>
+      <span class="ots-staging-banner__description">{description}</span>
+    </p>
+    <a class="ots-staging-banner__link" href={productionHref}>
+      {goToProduction}
+    </a>
+  </div>
+</div>
+
+<style>
+  .ots-staging-banner {
+    position: fixed;
+    inset-block-start: 0;
+    inset-inline: 0;
+    /* Above Starlight's navbar/menu/skiplink (z 4–20) so it sits at the very
+       top, and below the watermark (z 9999). */
+    z-index: 1000;
+    height: var(--ots-staging-banner-h);
+    background-color: #fffbeb; /* amber-50 */
+    color: #78350f; /* amber-900 */
+    border-block-end: 1px solid #fcd34d; /* amber-300 */
+  }
+
+  .ots-staging-banner__inner {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    height: 100%;
+    max-width: 87.5rem;
+    margin-inline: auto;
+    padding-inline: clamp(0.75rem, 3vw, 2rem);
+  }
+
+  .ots-staging-banner__icon {
+    flex: none;
+    width: 1.125rem;
+    height: 1.125rem;
+    color: #b45309; /* amber-700 */
+  }
+
+  .ots-staging-banner__text {
+    margin: 0;
+    min-width: 0;
+    flex: 1 1 auto;
+    /* Keep the strip a single, predictable row so --ots-staging-banner-h stays
+       accurate; overflow is truncated rather than wrapped. */
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 0.8125rem;
+    line-height: 1.2;
+  }
+
+  .ots-staging-banner__warning {
+    font-weight: 600;
+  }
+
+  .ots-staging-banner__description {
+    color: #92400e; /* amber-800 */
+    margin-inline-start: 0.5ch;
+  }
+
+  /* The longer description is supplementary — hide it on narrow screens so the
+     warning and the production link always stay visible. */
+  @media (max-width: 36rem) {
+    .ots-staging-banner__description {
+      display: none;
+    }
+  }
+
+  .ots-staging-banner__link {
+    flex: none;
+    display: inline-flex;
+    align-items: center;
+    padding: 0.25rem 0.625rem;
+    border: 1px solid #f59e0b; /* amber-500 */
+    border-radius: 6px;
+    background-color: rgb(255 255 255 / 0.7);
+    color: #78350f; /* amber-900 */
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-decoration: none;
+    white-space: nowrap;
+    transition:
+      background-color 0.15s ease,
+      border-color 0.15s ease;
+  }
+
+  .ots-staging-banner__link:hover {
+    background-color: #fffbeb; /* amber-50 */
+    border-color: #d97706; /* amber-600 */
+  }
+
+  /* --- Dark mode (Starlight's data-theme toggle) --- */
+  :global(:root[data-theme="dark"]) .ots-staging-banner {
+    background-color: #451a03; /* amber-950 */
+    color: #fef3c7; /* amber-100 */
+    border-block-end-color: #92400e; /* amber-800 */
+  }
+
+  :global(:root[data-theme="dark"]) .ots-staging-banner__icon {
+    color: #fbbf24; /* amber-400 */
+  }
+
+  :global(:root[data-theme="dark"]) .ots-staging-banner__description {
+    color: #fde68a; /* amber-200 */
+  }
+
+  :global(:root[data-theme="dark"]) .ots-staging-banner__link {
+    background-color: rgb(146 64 14 / 0.45); /* amber-800 @ 45% */
+    border-color: #b45309; /* amber-700 */
+    color: #fef3c7; /* amber-100 */
+  }
+
+  :global(:root[data-theme="dark"]) .ots-staging-banner__link:hover {
+    background-color: rgb(146 64 14 / 0.75);
+    border-color: #d97706; /* amber-600 */
+  }
+</style>

--- a/src/components/starlight/StagingBanner.astro
+++ b/src/components/starlight/StagingBanner.astro
@@ -26,7 +26,7 @@ import { CANONICAL_ORIGIN } from "../../../config/domains.mjs";
 const t = Astro.locals?.t;
 const warning = t
   ? t("staging.bannerWarning")
-  : "You're viewing the staging documentation site";
+  : "You're viewing the prerelease documentation site";
 const description = t
   ? t("staging.bannerDescription")
   : "Content here is for testing and may differ from the live docs.";

--- a/src/components/starlight/StagingWatermark.astro
+++ b/src/components/starlight/StagingWatermark.astro
@@ -1,0 +1,90 @@
+---
+// src/components/starlight/StagingWatermark.astro
+//
+// Full-page diagonal "STAGING" watermark overlay for the documentation site.
+//
+// This is the docs-site counterpart to the company site's
+// `StagingWatermark.vue`. It paints a repeating, rotated "STAGING" stamp over
+// the whole viewport (the legal-document "COPY"/"DUPLICATE" effect) so the
+// staging deploy is unmistakable at a glance.
+//
+// Docs-specific considerations:
+//   - `pointer-events: none` means it never blocks reading, selecting text,
+//     copying code blocks, or any link/menu interaction underneath.
+//   - `aria-hidden` keeps it out of the accessibility tree.
+//   - The opacity is kept very low (0.05). Documentation is dense, text-heavy,
+//     and full of code blocks, so the stamp must stay faint enough not to hurt
+//     readability or contrast while remaining noticeable.
+//   - Two colour layers are rendered and toggled via Starlight's
+//     `:root[data-theme='dark']` switch, because an SVG data URI can't read
+//     `currentColor`.
+
+// Build a repeating SVG tile data URI containing the word "STAGING".
+function buildSvgBackground(color: string): string {
+  const svg = [
+    '<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">',
+    '<text x="200" y="110" text-anchor="middle"',
+    ' font-size="48" font-weight="900" font-family="sans-serif"',
+    ' letter-spacing="0.2em"',
+    ` fill="${color}">STAGING</text>`,
+    "</svg>",
+  ].join("");
+  return `url("data:image/svg+xml,${encodeURIComponent(svg)}")`;
+}
+
+// amber-900 for light mode, amber-200 for dark mode (matches the banner).
+const lightBg = buildSvgBackground("#78350f");
+const darkBg = buildSvgBackground("#fde68a");
+---
+
+<div class="ots-staging-watermark print:hidden" aria-hidden="true">
+  <!--
+    The inner layers are oversized (200vmax square) and rotated so the
+    repeating tile covers the whole viewport diagonally with no visible
+    corners, regardless of aspect ratio.
+  -->
+  <div class="ots-staging-watermark__layer ots-staging-watermark__layer--light" style={`background-image:${lightBg}`}>
+  </div>
+  <div class="ots-staging-watermark__layer ots-staging-watermark__layer--dark" style={`background-image:${darkBg}`}>
+  </div>
+</div>
+
+<style>
+  .ots-staging-watermark {
+    position: fixed;
+    inset: 0;
+    /* Above all Starlight chrome and the banner so the stamp reads as a single
+       overlay across the whole page. pointer-events:none keeps it inert. */
+    z-index: 9999;
+    pointer-events: none;
+    user-select: none;
+    overflow: hidden;
+  }
+
+  .ots-staging-watermark__layer {
+    position: absolute;
+    inset-block-start: 50%;
+    inset-inline-start: 50%;
+    width: 200vmax;
+    height: 200vmax;
+    transform: translate(-50%, -50%) rotate(-30deg);
+    background-repeat: repeat;
+    background-size: 400px 200px;
+  }
+
+  .ots-staging-watermark__layer--light {
+    opacity: 0.05;
+  }
+
+  .ots-staging-watermark__layer--dark {
+    opacity: 0;
+  }
+
+  :global(:root[data-theme="dark"]) .ots-staging-watermark__layer--light {
+    opacity: 0;
+  }
+
+  :global(:root[data-theme="dark"]) .ots-staging-watermark__layer--dark {
+    opacity: 0.05;
+  }
+</style>

--- a/src/components/starlight/StagingWatermark.astro
+++ b/src/components/starlight/StagingWatermark.astro
@@ -1,32 +1,32 @@
 ---
 // src/components/starlight/StagingWatermark.astro
 //
-// Full-page diagonal "STAGING" watermark overlay for the documentation site.
+// Full-page diagonal "PRERELEASE" watermark overlay for the documentation site.
 //
 // This is the docs-site counterpart to the company site's
-// `StagingWatermark.vue`. It paints a repeating, rotated "STAGING" stamp over
-// the whole viewport (the legal-document "COPY"/"DUPLICATE" effect) so the
-// staging deploy is unmistakable at a glance.
+// `StagingWatermark.vue`. It paints a repeating, rotated "PRERELEASE" stamp
+// over the whole viewport (the legal-document "COPY"/"DUPLICATE" effect) so the
+// prerelease (staging) deploy is unmistakable at a glance.
 //
 // Docs-specific considerations:
 //   - `pointer-events: none` means it never blocks reading, selecting text,
 //     copying code blocks, or any link/menu interaction underneath.
 //   - `aria-hidden` keeps it out of the accessibility tree.
-//   - The opacity is kept very low (0.05). Documentation is dense, text-heavy,
+//   - The opacity is kept low (0.07–0.08). Documentation is dense, text-heavy,
 //     and full of code blocks, so the stamp must stay faint enough not to hurt
 //     readability or contrast while remaining noticeable.
 //   - Two colour layers are rendered and toggled via Starlight's
 //     `:root[data-theme='dark']` switch, because an SVG data URI can't read
 //     `currentColor`.
 
-// Build a repeating SVG tile data URI containing the word "STAGING".
+// Build a repeating SVG tile data URI containing the word "PRERELEASE".
 function buildSvgBackground(color: string): string {
   const svg = [
-    '<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">',
-    '<text x="200" y="110" text-anchor="middle"',
+    '<svg xmlns="http://www.w3.org/2000/svg" width="560" height="200">',
+    '<text x="280" y="110" text-anchor="middle"',
     ' font-size="48" font-weight="900" font-family="sans-serif"',
     ' letter-spacing="0.2em"',
-    ` fill="${color}">STAGING</text>`,
+    ` fill="${color}">PRERELEASE</text>`,
     "</svg>",
   ].join("");
   return `url("data:image/svg+xml,${encodeURIComponent(svg)}")`;
@@ -69,11 +69,11 @@ const darkBg = buildSvgBackground("#fde68a");
     height: 200vmax;
     transform: translate(-50%, -50%) rotate(-30deg);
     background-repeat: repeat;
-    background-size: 400px 200px;
+    background-size: 560px 200px;
   }
 
   .ots-staging-watermark__layer--light {
-    opacity: 0.05;
+    opacity: 0.08;
   }
 
   .ots-staging-watermark__layer--dark {
@@ -85,6 +85,6 @@ const darkBg = buildSvgBackground("#fde68a");
   }
 
   :global(:root[data-theme="dark"]) .ots-staging-watermark__layer--dark {
-    opacity: 0.05;
+    opacity: 0.07;
   }
 </style>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -11,6 +11,11 @@ export const collections = {
     schema: i18nSchema({
       extend: z.object({
         "custom.label": z.string().optional(),
+        // Staging banner (StagingBanner.astro). Optional so locales that
+        // haven't been translated yet fall back to English per-key.
+        "staging.bannerWarning": z.string().optional(),
+        "staging.bannerDescription": z.string().optional(),
+        "staging.goToProduction": z.string().optional(),
         // Custom 404 page (src/pages/404.astro). Optional so locales that
         // haven't been translated yet fall back to English per-key.
         "notFound.title": z.string().optional(),

--- a/src/content/i18n/bg.json
+++ b/src/content/i18n/bg.json
@@ -67,6 +67,9 @@
     "apiExplorer": "API Изследовател",
     "apiReference": "API Справка"
   },
+  "staging.bannerWarning": "Преглеждате тестовия сайт с документация",
+  "staging.bannerDescription": "Съдържанието тук е за тестване и може да се различава от продукционната документация.",
+  "staging.goToProduction": "Към продукционната документация",
   "skipLink.label": "Преминаване към съдържанието",
   "search.label": "Търсене",
   "search.ctrlKey": "Ctrl",

--- a/src/content/i18n/bg.json
+++ b/src/content/i18n/bg.json
@@ -67,7 +67,7 @@
     "apiExplorer": "API Изследовател",
     "apiReference": "API Справка"
   },
-  "staging.bannerWarning": "Преглеждате тестовия сайт с документация",
+  "staging.bannerWarning": "Преглеждате предварителния сайт с документация",
   "staging.bannerDescription": "Съдържанието тук е за тестване и може да се различава от продукционната документация.",
   "staging.goToProduction": "Към продукционната документация",
   "skipLink.label": "Преминаване към съдържанието",

--- a/src/content/i18n/da.json
+++ b/src/content/i18n/da.json
@@ -67,6 +67,9 @@
     "apiExplorer": "API-udforsker",
     "apiReference": "API-reference"
   },
+  "staging.bannerWarning": "Du ser staging-versionen af dokumentationen",
+  "staging.bannerDescription": "Indholdet her er til test og kan afvige fra den live dokumentation.",
+  "staging.goToProduction": "Gå til live dokumentation",
   "skipLink.label": "Spring til indhold",
   "search.label": "Søg",
   "search.ctrlKey": "Ctrl",

--- a/src/content/i18n/da.json
+++ b/src/content/i18n/da.json
@@ -67,7 +67,7 @@
     "apiExplorer": "API-udforsker",
     "apiReference": "API-reference"
   },
-  "staging.bannerWarning": "Du ser staging-versionen af dokumentationen",
+  "staging.bannerWarning": "Du ser forhåndsversionen af dokumentationen",
   "staging.bannerDescription": "Indholdet her er til test og kan afvige fra den live dokumentation.",
   "staging.goToProduction": "Gå til live dokumentation",
   "skipLink.label": "Spring til indhold",

--- a/src/content/i18n/de.json
+++ b/src/content/i18n/de.json
@@ -66,6 +66,9 @@
     "apiExplorer": "API Explorer",
     "apiReference": "API-Referenz"
   },
+  "staging.bannerWarning": "Sie sehen die Staging-Version der Dokumentation",
+  "staging.bannerDescription": "Inhalte dienen hier nur zu Testzwecken und können von der Live-Dokumentation abweichen.",
+  "staging.goToProduction": "Zur Live-Dokumentation",
   "skipLink.label": "Zum Inhalt springen",
   "search.label": "Suche",
   "search.ctrlKey": "Strg",

--- a/src/content/i18n/de.json
+++ b/src/content/i18n/de.json
@@ -66,7 +66,7 @@
     "apiExplorer": "API Explorer",
     "apiReference": "API-Referenz"
   },
-  "staging.bannerWarning": "Sie sehen die Staging-Version der Dokumentation",
+  "staging.bannerWarning": "Sie sehen die Vorabversion der Dokumentation",
   "staging.bannerDescription": "Inhalte dienen hier nur zu Testzwecken und können von der Live-Dokumentation abweichen.",
   "staging.goToProduction": "Zur Live-Dokumentation",
   "skipLink.label": "Zum Inhalt springen",

--- a/src/content/i18n/en.json
+++ b/src/content/i18n/en.json
@@ -82,7 +82,7 @@
     "apiExplorer": "API Explorer",
     "apiReference": "API Reference"
   },
-  "staging.bannerWarning": "You're viewing the staging documentation site",
+  "staging.bannerWarning": "You're viewing the prerelease documentation site",
   "staging.bannerDescription": "Content here is for testing and may differ from the live docs.",
   "staging.goToProduction": "Go to live docs",
   "skipLink.label": "Skip to content",

--- a/src/content/i18n/en.json
+++ b/src/content/i18n/en.json
@@ -82,6 +82,9 @@
     "apiExplorer": "API Explorer",
     "apiReference": "API Reference"
   },
+  "staging.bannerWarning": "You're viewing the staging documentation site",
+  "staging.bannerDescription": "Content here is for testing and may differ from the live docs.",
+  "staging.goToProduction": "Go to live docs",
   "skipLink.label": "Skip to content",
   "search.label": "Search",
   "search.ctrlKey": "Ctrl",

--- a/src/content/i18n/es.json
+++ b/src/content/i18n/es.json
@@ -66,7 +66,7 @@
     "apiExplorer": "API Explorador",
     "apiReference": "Referencia de API"
   },
-  "staging.bannerWarning": "Estás viendo el sitio de documentación de staging",
+  "staging.bannerWarning": "Estás viendo el sitio de documentación de versión preliminar",
   "staging.bannerDescription": "El contenido aquí es para pruebas y puede diferir de la documentación de producción.",
   "staging.goToProduction": "Ir a la documentación de producción",
   "skipLink.label": "Saltar al contenido",

--- a/src/content/i18n/es.json
+++ b/src/content/i18n/es.json
@@ -66,6 +66,9 @@
     "apiExplorer": "API Explorador",
     "apiReference": "Referencia de API"
   },
+  "staging.bannerWarning": "Estás viendo el sitio de documentación de staging",
+  "staging.bannerDescription": "El contenido aquí es para pruebas y puede diferir de la documentación de producción.",
+  "staging.goToProduction": "Ir a la documentación de producción",
   "skipLink.label": "Saltar al contenido",
   "search.label": "Buscar",
   "search.ctrlKey": "Ctrl",

--- a/src/content/i18n/fr.json
+++ b/src/content/i18n/fr.json
@@ -66,7 +66,7 @@
     "apiExplorer": "API Explorateur",
     "apiReference": "Référence API"
   },
-  "staging.bannerWarning": "Vous consultez le site de documentation en environnement de préproduction",
+  "staging.bannerWarning": "Vous consultez le site de documentation en préversion",
   "staging.bannerDescription": "Ce contenu est destiné aux tests et peut différer de la documentation de production.",
   "staging.goToProduction": "Accéder à la documentation de production",
   "skipLink.label": "Passer au contenu",

--- a/src/content/i18n/fr.json
+++ b/src/content/i18n/fr.json
@@ -66,6 +66,9 @@
     "apiExplorer": "API Explorateur",
     "apiReference": "Référence API"
   },
+  "staging.bannerWarning": "Vous consultez le site de documentation en environnement de préproduction",
+  "staging.bannerDescription": "Ce contenu est destiné aux tests et peut différer de la documentation de production.",
+  "staging.goToProduction": "Accéder à la documentation de production",
   "skipLink.label": "Passer au contenu",
   "search.label": "Rechercher",
   "search.ctrlKey": "Ctrl",

--- a/src/content/i18n/it.json
+++ b/src/content/i18n/it.json
@@ -66,7 +66,7 @@
     "apiExplorer": "API Esploratore",
     "apiReference": "Riferimento API"
   },
-  "staging.bannerWarning": "Stai visualizzando il sito di documentazione di staging",
+  "staging.bannerWarning": "Stai visualizzando il sito di documentazione in anteprima",
   "staging.bannerDescription": "I contenuti qui servono per i test e possono differire dalla documentazione di produzione.",
   "staging.goToProduction": "Vai alla documentazione di produzione",
   "skipLink.label": "Vai al contenuto",

--- a/src/content/i18n/it.json
+++ b/src/content/i18n/it.json
@@ -66,6 +66,9 @@
     "apiExplorer": "API Esploratore",
     "apiReference": "Riferimento API"
   },
+  "staging.bannerWarning": "Stai visualizzando il sito di documentazione di staging",
+  "staging.bannerDescription": "I contenuti qui servono per i test e possono differire dalla documentazione di produzione.",
+  "staging.goToProduction": "Vai alla documentazione di produzione",
   "skipLink.label": "Vai al contenuto",
   "search.label": "Cerca",
   "search.ctrlKey": "Ctrl",

--- a/src/content/i18n/ja.json
+++ b/src/content/i18n/ja.json
@@ -67,7 +67,7 @@
     "apiExplorer": "API エクスプローラー",
     "apiReference": "API リファレンス"
   },
-  "staging.bannerWarning": "ステージング環境のドキュメントを表示しています",
+  "staging.bannerWarning": "プレリリース版のドキュメントを表示しています",
   "staging.bannerDescription": "こちらのコンテンツはテスト用であり、本番のドキュメントとは異なる場合があります。",
   "staging.goToProduction": "本番のドキュメントへ",
   "skipLink.label": "コンテンツにスキップ",

--- a/src/content/i18n/ja.json
+++ b/src/content/i18n/ja.json
@@ -67,6 +67,9 @@
     "apiExplorer": "API エクスプローラー",
     "apiReference": "API リファレンス"
   },
+  "staging.bannerWarning": "ステージング環境のドキュメントを表示しています",
+  "staging.bannerDescription": "こちらのコンテンツはテスト用であり、本番のドキュメントとは異なる場合があります。",
+  "staging.goToProduction": "本番のドキュメントへ",
   "skipLink.label": "コンテンツにスキップ",
   "search.label": "検索",
   "search.ctrlKey": "Ctrl",

--- a/src/content/i18n/ko.json
+++ b/src/content/i18n/ko.json
@@ -67,7 +67,7 @@
     "apiExplorer": "API 탐색기",
     "apiReference": "API 레퍼런스"
   },
-  "staging.bannerWarning": "스테이징 문서 사이트를 보고 있습니다",
+  "staging.bannerWarning": "사전 릴리스 문서 사이트를 보고 있습니다",
   "staging.bannerDescription": "여기 콘텐츠는 테스트용이며 실제 문서와 다를 수 있습니다.",
   "staging.goToProduction": "실제 문서로 이동",
   "skipLink.label": "콘텐츠로 건너뛰기",

--- a/src/content/i18n/ko.json
+++ b/src/content/i18n/ko.json
@@ -67,6 +67,9 @@
     "apiExplorer": "API 탐색기",
     "apiReference": "API 레퍼런스"
   },
+  "staging.bannerWarning": "스테이징 문서 사이트를 보고 있습니다",
+  "staging.bannerDescription": "여기 콘텐츠는 테스트용이며 실제 문서와 다를 수 있습니다.",
+  "staging.goToProduction": "실제 문서로 이동",
   "skipLink.label": "콘텐츠로 건너뛰기",
   "search.label": "검색",
   "search.ctrlKey": "Ctrl",

--- a/src/content/i18n/mi.json
+++ b/src/content/i18n/mi.json
@@ -67,7 +67,7 @@
     "apiExplorer": "API Tūhuranga",
     "apiReference": "API Tohutoro"
   },
-  "staging.bannerWarning": "Kei te tirohia e koe te pae tuhinga whakamātau (staging)",
+  "staging.bannerWarning": "Kei te tirohia e koe te pae tuhinga whakaaturanga (prerelease)",
   "staging.bannerDescription": "He mea whakamātau ngā ihirangi i konei, tērā pea ka rerekē i ngā tuhinga whakaputa.",
   "staging.goToProduction": "Haere ki ngā tuhinga whakaputa",
   "skipLink.label": "Peke ki te ihirangi",

--- a/src/content/i18n/mi.json
+++ b/src/content/i18n/mi.json
@@ -67,6 +67,9 @@
     "apiExplorer": "API Tūhuranga",
     "apiReference": "API Tohutoro"
   },
+  "staging.bannerWarning": "Kei te tirohia e koe te pae tuhinga whakamātau (staging)",
+  "staging.bannerDescription": "He mea whakamātau ngā ihirangi i konei, tērā pea ka rerekē i ngā tuhinga whakaputa.",
+  "staging.goToProduction": "Haere ki ngā tuhinga whakaputa",
   "skipLink.label": "Peke ki te ihirangi",
   "search.label": "Rapu",
   "search.ctrlKey": "Ctrl",

--- a/src/content/i18n/nl.json
+++ b/src/content/i18n/nl.json
@@ -67,6 +67,9 @@
     "apiExplorer": "API Verkenner",
     "apiReference": "API-referentie"
   },
+  "staging.bannerWarning": "Je bekijkt de staging-documentatiesite",
+  "staging.bannerDescription": "De inhoud hier dient om te testen en kan afwijken van de live documentatie.",
+  "staging.goToProduction": "Ga naar live documentatie",
   "skipLink.label": "Ga naar inhoud",
   "search.label": "Zoeken",
   "search.ctrlKey": "Ctrl",

--- a/src/content/i18n/nl.json
+++ b/src/content/i18n/nl.json
@@ -67,7 +67,7 @@
     "apiExplorer": "API Verkenner",
     "apiReference": "API-referentie"
   },
-  "staging.bannerWarning": "Je bekijkt de staging-documentatiesite",
+  "staging.bannerWarning": "Je bekijkt de previewversie van de documentatiesite",
   "staging.bannerDescription": "De inhoud hier dient om te testen en kan afwijken van de live documentatie.",
   "staging.goToProduction": "Ga naar live documentatie",
   "skipLink.label": "Ga naar inhoud",

--- a/src/content/i18n/pl.json
+++ b/src/content/i18n/pl.json
@@ -67,7 +67,7 @@
     "apiExplorer": "API Eksplorator",
     "apiReference": "Dokumentacja API"
   },
-  "staging.bannerWarning": "Przeglądasz testową wersję dokumentacji",
+  "staging.bannerWarning": "Przeglądasz przedpremierową wersję dokumentacji",
   "staging.bannerDescription": "Treści tutaj służą do testów i mogą różnić się od dokumentacji produkcyjnej.",
   "staging.goToProduction": "Przejdź do dokumentacji produkcyjnej",
   "skipLink.label": "Przejdź do treści",

--- a/src/content/i18n/pl.json
+++ b/src/content/i18n/pl.json
@@ -67,6 +67,9 @@
     "apiExplorer": "API Eksplorator",
     "apiReference": "Dokumentacja API"
   },
+  "staging.bannerWarning": "Przeglądasz testową wersję dokumentacji",
+  "staging.bannerDescription": "Treści tutaj służą do testów i mogą różnić się od dokumentacji produkcyjnej.",
+  "staging.goToProduction": "Przejdź do dokumentacji produkcyjnej",
   "skipLink.label": "Przejdź do treści",
   "search.label": "Wyszukaj",
   "search.ctrlKey": "Ctrl",

--- a/src/content/i18n/pt-br.json
+++ b/src/content/i18n/pt-br.json
@@ -67,7 +67,7 @@
     "apiExplorer": "API Explorador",
     "apiReference": "Referência da API"
   },
-  "staging.bannerWarning": "Você está vendo o site de documentação de staging",
+  "staging.bannerWarning": "Você está vendo o site de documentação de pré-lançamento",
   "staging.bannerDescription": "O conteúdo aqui é para testes e pode diferir da documentação de produção.",
   "staging.goToProduction": "Ir para a documentação de produção",
   "skipLink.label": "Pular para o conteúdo",

--- a/src/content/i18n/pt-br.json
+++ b/src/content/i18n/pt-br.json
@@ -67,6 +67,9 @@
     "apiExplorer": "API Explorador",
     "apiReference": "Referência da API"
   },
+  "staging.bannerWarning": "Você está vendo o site de documentação de staging",
+  "staging.bannerDescription": "O conteúdo aqui é para testes e pode diferir da documentação de produção.",
+  "staging.goToProduction": "Ir para a documentação de produção",
   "skipLink.label": "Pular para o conteúdo",
   "search.label": "Buscar",
   "search.ctrlKey": "Ctrl",

--- a/src/content/i18n/sv.json
+++ b/src/content/i18n/sv.json
@@ -67,7 +67,7 @@
     "apiExplorer": "API-utforskare",
     "apiReference": "API-referens"
   },
-  "staging.bannerWarning": "Du visar staging-versionen av dokumentationen",
+  "staging.bannerWarning": "Du visar förhandsversionen av dokumentationen",
   "staging.bannerDescription": "Innehållet här är för testning och kan skilja sig från den publika dokumentationen.",
   "staging.goToProduction": "Gå till den publika dokumentationen",
   "skipLink.label": "Hoppa till innehåll",

--- a/src/content/i18n/sv.json
+++ b/src/content/i18n/sv.json
@@ -67,6 +67,9 @@
     "apiExplorer": "API-utforskare",
     "apiReference": "API-referens"
   },
+  "staging.bannerWarning": "Du visar staging-versionen av dokumentationen",
+  "staging.bannerDescription": "Innehållet här är för testning och kan skilja sig från den publika dokumentationen.",
+  "staging.goToProduction": "Gå till den publika dokumentationen",
   "skipLink.label": "Hoppa till innehåll",
   "search.label": "Sök",
   "search.ctrlKey": "Ctrl",

--- a/src/content/i18n/tr.json
+++ b/src/content/i18n/tr.json
@@ -67,6 +67,9 @@
     "apiExplorer": "API Gezgini",
     "apiReference": "API Referansı"
   },
+  "staging.bannerWarning": "Staging (test) belgeler sitesini görüntülüyorsunuz",
+  "staging.bannerDescription": "Buradaki içerik test amaçlıdır ve canlı belgelerden farklı olabilir.",
+  "staging.goToProduction": "Canlı belgelere git",
   "skipLink.label": "İçeriğe atla",
   "search.label": "Ara",
   "search.ctrlKey": "Ctrl",

--- a/src/content/i18n/tr.json
+++ b/src/content/i18n/tr.json
@@ -67,7 +67,7 @@
     "apiExplorer": "API Gezgini",
     "apiReference": "API Referansı"
   },
-  "staging.bannerWarning": "Staging (test) belgeler sitesini görüntülüyorsunuz",
+  "staging.bannerWarning": "Ön sürüm belgeler sitesini görüntülüyorsunuz",
   "staging.bannerDescription": "Buradaki içerik test amaçlıdır ve canlı belgelerden farklı olabilir.",
   "staging.goToProduction": "Canlı belgelere git",
   "skipLink.label": "İçeriğe atla",

--- a/src/content/i18n/uk.json
+++ b/src/content/i18n/uk.json
@@ -67,7 +67,7 @@
     "apiExplorer": "API Оглядач",
     "apiReference": "API Довідник"
   },
-  "staging.bannerWarning": "Ви переглядаєте staging-версію сайту документації",
+  "staging.bannerWarning": "Ви переглядаєте попередню версію сайту документації",
   "staging.bannerDescription": "Вміст тут призначений для тестування й може відрізнятися від актуальної документації.",
   "staging.goToProduction": "Перейти до актуальної документації",
   "skipLink.label": "Перейти до вмісту",

--- a/src/content/i18n/uk.json
+++ b/src/content/i18n/uk.json
@@ -67,6 +67,9 @@
     "apiExplorer": "API Оглядач",
     "apiReference": "API Довідник"
   },
+  "staging.bannerWarning": "Ви переглядаєте staging-версію сайту документації",
+  "staging.bannerDescription": "Вміст тут призначений для тестування й може відрізнятися від актуальної документації.",
+  "staging.goToProduction": "Перейти до актуальної документації",
   "skipLink.label": "Перейти до вмісту",
   "search.label": "Пошук",
   "search.ctrlKey": "Ctrl",

--- a/src/content/i18n/zh-cn.json
+++ b/src/content/i18n/zh-cn.json
@@ -67,7 +67,7 @@
     "apiExplorer": "API 探索器",
     "apiReference": "API 参考"
   },
-  "staging.bannerWarning": "您正在浏览预发布（staging）文档站点",
+  "staging.bannerWarning": "您正在浏览预发布文档站点",
   "staging.bannerDescription": "此处内容仅供测试，可能与正式文档有所不同。",
   "staging.goToProduction": "前往正式文档",
   "skipLink.label": "跳转到内容",

--- a/src/content/i18n/zh-cn.json
+++ b/src/content/i18n/zh-cn.json
@@ -67,6 +67,9 @@
     "apiExplorer": "API 探索器",
     "apiReference": "API 参考"
   },
+  "staging.bannerWarning": "您正在浏览预发布（staging）文档站点",
+  "staging.bannerDescription": "此处内容仅供测试，可能与正式文档有所不同。",
+  "staging.goToProduction": "前往正式文档",
   "skipLink.label": "跳转到内容",
   "search.label": "搜索",
   "search.ctrlKey": "Ctrl",

--- a/src/styles/staging.css
+++ b/src/styles/staging.css
@@ -1,0 +1,87 @@
+/* src/styles/staging.css
+ *
+ * Staging-only layout adjustments.
+ *
+ * This stylesheet is added to Starlight's `customCss` ONLY on staging builds
+ * (see config/starlight.mjs), so production never loads it. Its job is to make
+ * room for the fixed staging banner (StagingBanner.astro): Starlight's header,
+ * left sidebar, right table-of-contents, and mobile TOC bar are all
+ * `position: fixed` anchored to the top of the viewport, so each must be
+ * pushed down by the banner's height. Everything is expressed relative to a
+ * single custom property, `--ots-staging-banner-h`, so the layout stays in
+ * sync if the banner height changes.
+ *
+ * Specificity / cascade: Starlight's own layout rules live in
+ * `@layer starlight.core`. These overrides are intentionally unlayered, and
+ * unlayered rules beat any layered rule regardless of specificity, so they
+ * apply cleanly without `!important`.
+ */
+
+:root {
+  /* Height of the fixed staging banner. Keep in sync with the `height` set on
+     .ots-staging-banner in StagingBanner.astro. */
+  --ots-staging-banner-h: 2.5rem;
+}
+
+/* Push the fixed top navbar below the banner. */
+header.header {
+  inset-block-start: var(--ots-staging-banner-h);
+}
+
+/* Push the fixed left sidebar (and its mobile drop-down pane) below the
+   banner + navbar. */
+.sidebar-pane {
+  inset-block-start: calc(var(--sl-nav-height) + var(--ots-staging-banner-h));
+}
+
+/* Push the main content column's top padding down so content clears the
+   banner. (--sl-nav-height + --sl-mobile-toc-height are Starlight's existing
+   offsets; we add the banner on top.) */
+.main-frame {
+  padding-top: calc(
+    var(--sl-nav-height) + var(--sl-mobile-toc-height) +
+      var(--ots-staging-banner-h)
+  );
+}
+
+/* Mobile "On this page" table-of-contents bar, fixed just under the navbar. */
+mobile-starlight-toc nav {
+  inset-block-start: calc(
+    var(--sl-nav-height) - 1px + var(--ots-staging-banner-h)
+  );
+}
+
+/* Desktop right-hand table of contents: a fixed, full-height column whose
+   content is padded down past the navbar — add the banner height too. */
+@media (min-width: 72rem) {
+  .right-sidebar {
+    padding-top: calc(var(--sl-nav-height) + var(--ots-staging-banner-h));
+  }
+}
+
+/* Keep anchored headings (#fragment links) from landing under the banner +
+   navbar. Mirrors the scroll-padding-top rule in tailwind.css. */
+html {
+  scroll-padding-top: calc(
+    var(--sl-nav-height) + 1rem + var(--ots-staging-banner-h)
+  );
+}
+
+/* Starlight's "skip to content" link is fixed at top:0.75rem and only becomes
+   visible on focus; nudge it below the banner so keyboard users can see it
+   instead of it appearing behind the strip. (#_top is the page title id.) */
+a[href="#_top"] {
+  top: calc(0.75rem + var(--ots-staging-banner-h));
+}
+
+/* When printing, hide the banner/watermark and zero the offset so the printed
+   page has no empty band at the top. */
+@media print {
+  :root {
+    --ots-staging-banner-h: 0px;
+  }
+  .ots-staging-banner,
+  .ots-staging-watermark {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a fixed top banner and diagonal watermark overlay to the staging documentation site (docs.onetimesecret.dev), mirroring the visual indicators on the company site. These elements make it immediately obvious when viewing prerelease documentation rather than the live site.

## Key Changes

- **New staging components** (`StagingBanner.astro`, `StagingWatermark.astro`): 
  - Fixed amber warning banner at the top with icon, warning text, description, and link to production docs
  - Full-page diagonal "PRERELEASE" watermark overlay with low opacity to avoid blocking readability
  - Both components support dark mode via Starlight's `:root[data-theme='dark']` toggle
  - Zero client-side JavaScript — all rendered as static HTML at build time

- **Build-time staging detection** (`config/domains.mjs`):
  - Centralized domain configuration matching the company site
  - `isStagingBuild()` function detects staging environment from `SITE_URL` or explicit `STAGING_BANNER` environment variable
  - Prevents spoofing with strict hostname matching (exact match or subdomain only)

- **Layout adjustments** (`src/styles/staging.css`):
  - Offsets Starlight's fixed header, sidebars, and TOC by banner height (`--ots-staging-banner-h`)
  - Only loaded on staging builds; production is unaffected
  - Ensures nothing is hidden behind the fixed banner
  - Hides banner and watermark when printing

- **Starlight integration** (`config/starlight.mjs`, `PageFrame.astro`):
  - Conditionally overrides `PageFrame` component only on staging builds
  - Wraps default Starlight layout to mount banner and watermark above page content
  - Inherits all Starlight layout behavior (header, sidebar, mobile menu, etc.)

- **Internationalization**:
  - Added `staging.bannerWarning`, `staging.bannerDescription`, and `staging.goToProduction` keys to all 16 language files
  - Falls back to English if translation is missing

## Implementation Details

- **No layout shift or flash**: Banner is baked into static HTML at build time, not injected client-side
- **Accessibility**: Banner has `aria-label`, watermark has `aria-hidden`; skip-to-content link is repositioned to stay visible
- **Responsive**: Banner description hides on screens narrower than 36rem; text truncates rather than wraps to maintain single-row height
- **Print-friendly**: Banner and watermark are hidden and layout offsets zeroed when printing
- **Dark mode**: Both components use Starlight's native theme toggle; colors match the amber palette used in the banner

https://claude.ai/code/session_012Q8sNuNttzYWZRDq9RS9zs