### PR TITLE
Update OCI image version to v0.25.11 across all self-hosting docs

### DIFF
--- a/src/content/docs/bg/self-hosting/index.md
+++ b/src/content/docs/bg/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.10
+  onetimesecret/onetimesecret:v0.25.11
 ```
 
 Достъп на `http://localhost:3000`.

--- a/src/content/docs/da/self-hosting/getting-started.md
+++ b/src/content/docs/da/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.10
+  onetimesecret/onetimesecret:v0.25.11
 ```
 
 ### 4. Få adgang til din instans

--- a/src/content/docs/da/self-hosting/index.md
+++ b/src/content/docs/da/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.10
+  onetimesecret/onetimesecret:v0.25.11
 ```
 
 Få adgang på `http://localhost:3000`.

--- a/src/content/docs/de/self-hosting/index.md
+++ b/src/content/docs/de/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.10
+  onetimesecret/onetimesecret:v0.25.11
 ```
 
 Erreichbar unter `http://localhost:3000`.

--- a/src/content/docs/en/self-hosting/getting-started.md
+++ b/src/content/docs/en/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.10
+  onetimesecret/onetimesecret:v0.25.11
 ```
 
 ### 4. Access Your Instance

--- a/src/content/docs/en/self-hosting/index.md
+++ b/src/content/docs/en/self-hosting/index.md
@@ -36,7 +36,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.10
+  onetimesecret/onetimesecret:v0.25.11
 ```
 
 Access at `http://localhost:3000`.

--- a/src/content/docs/en/self-hosting/installation.md
+++ b/src/content/docs/en/self-hosting/installation.md
@@ -34,7 +34,7 @@ version: '3.8'
 
 services:
   onetime:
-    image: onetimesecret/onetimesecret:v0.25.10
+    image: onetimesecret/onetimesecret:v0.25.11
     ports:
       - "3000:3000"
     environment:

--- a/src/content/docs/es/self-hosting/index.md
+++ b/src/content/docs/es/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.10
+  onetimesecret/onetimesecret:v0.25.11
 ```
 
 Acceda en `http://localhost:3000`.

--- a/src/content/docs/fr/self-hosting/index.md
+++ b/src/content/docs/fr/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.10
+  onetimesecret/onetimesecret:v0.25.11
 ```
 
 Accessible à l'adresse `http://localhost:3000`.

--- a/src/content/docs/it/self-hosting/index.md
+++ b/src/content/docs/it/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.10
+  onetimesecret/onetimesecret:v0.25.11
 ```
 
 Accessibile all'indirizzo `http://localhost:3000`.

--- a/src/content/docs/ja/self-hosting/index.md
+++ b/src/content/docs/ja/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.10
+  onetimesecret/onetimesecret:v0.25.11
 ```
 
 `http://localhost:3000` でアクセスできます。

--- a/src/content/docs/ko/self-hosting/index.md
+++ b/src/content/docs/ko/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.10
+  onetimesecret/onetimesecret:v0.25.11
 ```
 
 `http://localhost:3000`에서 접속할 수 있습니다.

--- a/src/content/docs/mi/self-hosting/getting-started.md
+++ b/src/content/docs/mi/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.10
+  onetimesecret/onetimesecret:v0.25.11
 ```
 
 ### 4. Uru ki Tō Tauira

--- a/src/content/docs/mi/self-hosting/index.md
+++ b/src/content/docs/mi/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.10
+  onetimesecret/onetimesecret:v0.25.11
 ```
 
 Uru mai i `http://localhost:3000`.

--- a/src/content/docs/mi/self-hosting/installation.md
+++ b/src/content/docs/mi/self-hosting/installation.md
@@ -34,7 +34,7 @@ version: '3.8'
 
 services:
   onetime:
-    image: onetimesecret/onetimesecret:v0.25.10
+    image: onetimesecret/onetimesecret:v0.25.11
     ports:
       - "3000:3000"
     environment:

--- a/src/content/docs/nl/self-hosting/index.md
+++ b/src/content/docs/nl/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.10
+  onetimesecret/onetimesecret:v0.25.11
 ```
 
 Toegankelijk op `http://localhost:3000`.

--- a/src/content/docs/pl/self-hosting/index.md
+++ b/src/content/docs/pl/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.10
+  onetimesecret/onetimesecret:v0.25.11
 ```
 
 Dostęp pod adresem `http://localhost:3000`.

--- a/src/content/docs/pt-br/self-hosting/getting-started.md
+++ b/src/content/docs/pt-br/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.10
+  onetimesecret/onetimesecret:v0.25.11
 ```
 
 ### 4. Acessar Sua Instância

--- a/src/content/docs/pt-br/self-hosting/index.md
+++ b/src/content/docs/pt-br/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.10
+  onetimesecret/onetimesecret:v0.25.11
 ```
 
 Acesse em `http://localhost:3000`.

--- a/src/content/docs/sv/self-hosting/getting-started.md
+++ b/src/content/docs/sv/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.10
+  onetimesecret/onetimesecret:v0.25.11
 ```
 
 ### 4. Få åtkomst till din instans

--- a/src/content/docs/sv/self-hosting/index.md
+++ b/src/content/docs/sv/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.10
+  onetimesecret/onetimesecret:v0.25.11
 ```
 
 Åtkomst på `http://localhost:3000`.

--- a/src/content/docs/sv/self-hosting/installation.md
+++ b/src/content/docs/sv/self-hosting/installation.md
@@ -34,7 +34,7 @@ version: '3.8'
 
 services:
   onetime:
-    image: onetimesecret/onetimesecret:v0.25.10
+    image: onetimesecret/onetimesecret:v0.25.11
     ports:
       - "3000:3000"
     environment:

--- a/src/content/docs/tr/self-hosting/getting-started.md
+++ b/src/content/docs/tr/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.10
+  onetimesecret/onetimesecret:v0.25.11
 ```
 
 ### 4. Örneğinize Erişin

--- a/src/content/docs/tr/self-hosting/index.md
+++ b/src/content/docs/tr/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.10
+  onetimesecret/onetimesecret:v0.25.11
 ```
 
 `http://localhost:3000` adresinden erişin.

--- a/src/content/docs/tr/self-hosting/installation.md
+++ b/src/content/docs/tr/self-hosting/installation.md
@@ -34,7 +34,7 @@ version: '3.8'
 
 services:
   onetime:
-    image: onetimesecret/onetimesecret:v0.25.10
+    image: onetimesecret/onetimesecret:v0.25.11
     ports:
       - "3000:3000"
     environment:

--- a/src/content/docs/uk/self-hosting/getting-started.md
+++ b/src/content/docs/uk/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.10
+  onetimesecret/onetimesecret:v0.25.11
 ```
 
 ### 4. Отримайте доступ до свого екземпляра

--- a/src/content/docs/uk/self-hosting/index.md
+++ b/src/content/docs/uk/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.10
+  onetimesecret/onetimesecret:v0.25.11
 ```
 
 Доступ за адресою `http://localhost:3000`.

--- a/src/content/docs/uk/self-hosting/installation.md
+++ b/src/content/docs/uk/self-hosting/installation.md
@@ -34,7 +34,7 @@ version: '3.8'
 
 services:
   onetime:
-    image: onetimesecret/onetimesecret:v0.25.10
+    image: onetimesecret/onetimesecret:v0.25.11
     ports:
       - "3000:3000"
     environment:

--- a/src/content/docs/zh-cn/self-hosting/getting-started.md
+++ b/src/content/docs/zh-cn/self-hosting/getting-started.md
@@ -41,7 +41,7 @@ docker run -p 3000:3000 -d \
   -e HOST=localhost:3000 \
   -e SSL=false \
   -e RACK_ENV=production \
-  onetimesecret/onetimesecret:v0.25.10
+  onetimesecret/onetimesecret:v0.25.11
 ```
 
 ### 4. 访问您的实例

--- a/src/content/docs/zh-cn/self-hosting/index.md
+++ b/src/content/docs/zh-cn/self-hosting/index.md
@@ -42,7 +42,7 @@ docker run -p 6379:6379 -d redis:bookworm
 docker run -p 3000:3000 -d \
   -e REDIS_URL=redis://host.docker.internal:6379/0 \
   -e SECRET="$(openssl rand -hex 32)" \
-  onetimesecret/onetimesecret:v0.25.10
+  onetimesecret/onetimesecret:v0.25.11
 ```
 
 访问 `http://localhost:3000`。

--- a/src/content/docs/zh-cn/self-hosting/installation.md
+++ b/src/content/docs/zh-cn/self-hosting/installation.md
@@ -34,7 +34,7 @@ version: '3.8'
 
 services:
   onetime:
-    image: onetimesecret/onetimesecret:v0.25.10
+    image: onetimesecret/onetimesecret:v0.25.11
     ports:
       - "3000:3000"
     environment:


### PR DESCRIPTION
The `latest` tag on ghcr.io/onetimesecret/onetimesecret now resolves to
v0.25.11 (verified via Docker Hub digest match). Updated all 31 self-hosting
documentation files (en + 15 language translations) from v0.25.10 to v0.25.11
to pin new installs to the current release rather than a floating tag.