### PR TITLE
Add the Configuration Generator (schema-driven, in the docs site)

### DIFF
--- a/config/sidebar.mjs
+++ b/config/sidebar.mjs
@@ -211,6 +211,7 @@ export const sidebar = [
     createLink("gettingStarted", "self-hosting/getting-started"),
     createLink("installationDeployment", "self-hosting/installation"),
     createLink("configurationReference", "self-hosting/configuration"),
+    createLink("configurationGenerator", "self-hosting/configuration-generator"),
     createLink("environmentVariables", "self-hosting/environment-variables"),
     createLink("upgradingToV023", "self-hosting/upgrading-v0-23"),
     createLink("upgradingToV024", "self-hosting/upgrading-v0-24"),

--- a/src/components/config-generator/ConfigGenerator.vue
+++ b/src/components/config-generator/ConfigGenerator.vue
@@ -1,0 +1,401 @@
+<!-- src/components/config-generator/ConfigGenerator.vue -->
+<!--
+  Configuration Generator — a self-contained, client-side tool that turns a
+  handful of preset choices into ready-to-use etc/config.yaml / etc/auth.yaml
+  override fragments plus a companion .env starter.
+
+  It runs entirely in the browser inside the docs site: the vendored config JSON
+  schemas (src/components/config-generator/schemas) provide field defaults and constraints, a
+  small preset manifest (presets.ts) supplies the curation and ENV mapping, and
+  the YAML is generated locally (generate.ts). No dependency on the running
+  application.
+
+  Selections are mirrored into the URL query string, so a configured link is
+  shareable and bookmarkable. Secrets are only ever shown as empty .env
+  placeholders — nothing sensitive is baked into the output.
+-->
+
+<script setup lang="ts">
+  import { computed, onMounted, reactive, ref, watch } from 'vue';
+  import { OPTIONS, type OptionSpec } from './presets';
+  import {
+    choicesFor,
+    coerce,
+    defaultFor,
+    defaultSelections,
+    generate,
+    toQuery,
+    type Selections,
+  } from './generate';
+
+  const selections = reactive<Selections>(defaultSelections());
+  const ready = ref(false);
+
+  const outputs = [
+    { key: 'configYaml' as const, label: 'config.yaml', filename: 'config.yaml' },
+    { key: 'authYaml' as const, label: 'auth.yaml', filename: 'auth.yaml' },
+    { key: 'envSnippet' as const, label: '.env', filename: '.env' },
+  ];
+  const activeOutput = ref<(typeof outputs)[number]['key']>('configYaml');
+  const copied = ref(false);
+
+  const result = computed(() => generate({ ...selections }));
+
+  const activeMeta = computed(
+    () => outputs.find((o) => o.key === activeOutput.value) ?? outputs[0]
+  );
+  const activeContent = computed(() => {
+    const content = result.value[activeOutput.value];
+    return content && content.length ? content : '# (defaults — nothing to override)\n';
+  });
+
+  function requirementMet(opt: OptionSpec): boolean {
+    if (!opt.requires) return true;
+    return Object.entries(opt.requires).every(([dep, val]) => selections[dep] === val);
+  }
+  function requirementHint(opt: OptionSpec): string {
+    if (!opt.requires) return '';
+    return Object.entries(opt.requires)
+      .map(([dep, val]) => {
+        const depOpt = OPTIONS.find((o) => o.key === dep);
+        const choice = depOpt && choicesFor(depOpt).find((c) => c.value === val);
+        return `${depOpt?.label ?? dep}: ${choice?.label ?? val}`;
+      })
+      .join(', ');
+  }
+
+  // ── URL <-> state sync ──────────────────────────────────────────────
+  function seedFromUrl() {
+    const params = new URLSearchParams(window.location.search);
+    for (const opt of OPTIONS) {
+      const raw = params.get(opt.key);
+      selections[opt.key] = raw == null ? defaultFor(opt) : coerce(opt, raw);
+    }
+  }
+  function syncUrl() {
+    const query = toQuery(selections);
+    const search = new URLSearchParams(query).toString();
+    const url = search ? `${window.location.pathname}?${search}` : window.location.pathname;
+    window.history.replaceState(null, '', url);
+  }
+
+  onMounted(() => {
+    seedFromUrl();
+    ready.value = true;
+    watch(selections, syncUrl, { deep: true });
+  });
+
+  // ── Copy / download ─────────────────────────────────────────────────
+  async function copyActive() {
+    try {
+      await navigator.clipboard.writeText(activeContent.value);
+      copied.value = true;
+      setTimeout(() => (copied.value = false), 1500);
+    } catch {
+      /* clipboard unavailable — user can still select the text */
+    }
+  }
+  function downloadActive() {
+    const blob = new Blob([activeContent.value], { type: 'text/plain;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = activeMeta.value.filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }
+</script>
+
+<template>
+  <div class="cg">
+    <div class="cg-grid">
+      <!-- ── Options ── -->
+      <section
+        class="cg-options"
+        aria-label="Configuration options">
+        <div
+          v-for="opt in OPTIONS"
+          :key="opt.key"
+          class="cg-option">
+          <div class="cg-option-head">
+            <label
+              :for="`cg-${opt.key}`"
+              class="cg-option-label"
+              >{{ opt.label }}</label
+            >
+
+            <button
+              v-if="opt.type === 'boolean'"
+              :id="`cg-${opt.key}`"
+              type="button"
+              role="switch"
+              :aria-checked="selections[opt.key] === true"
+              :disabled="!requirementMet(opt)"
+              class="cg-switch"
+              :class="{ on: selections[opt.key], off: !selections[opt.key] }"
+              @click="selections[opt.key] = !selections[opt.key]">
+              <span class="cg-knob" />
+            </button>
+          </div>
+
+          <p
+            v-if="opt.description"
+            class="cg-option-desc">
+            {{ opt.description }}
+          </p>
+          <p
+            v-if="opt.requires && !requirementMet(opt)"
+            class="cg-option-req">
+            Requires {{ requirementHint(opt) }}
+          </p>
+
+          <select
+            v-if="opt.type === 'select'"
+            :id="`cg-${opt.key}`"
+            v-model="selections[opt.key]"
+            class="cg-select">
+            <option
+              v-for="choice in choicesFor(opt)"
+              :key="String(choice.value)"
+              :value="choice.value">
+              {{ choice.label }}
+            </option>
+          </select>
+        </div>
+      </section>
+
+      <!-- ── Output ── -->
+      <section
+        class="cg-output"
+        aria-label="Generated configuration">
+        <ul
+          v-if="result.warnings.length"
+          class="cg-warnings">
+          <li
+            v-for="(w, i) in result.warnings"
+            :key="i">
+            {{ w }}
+          </li>
+        </ul>
+
+        <div class="cg-tabs">
+          <div
+            class="cg-tablist"
+            role="tablist">
+            <button
+              v-for="output in outputs"
+              :key="output.key"
+              type="button"
+              role="tab"
+              :aria-selected="activeOutput === output.key"
+              class="cg-tab"
+              :class="{ active: activeOutput === output.key }"
+              @click="activeOutput = output.key">
+              {{ output.label }}
+            </button>
+          </div>
+          <div class="cg-actions">
+            <button
+              type="button"
+              class="cg-btn"
+              @click="copyActive">
+              {{ copied ? 'Copied' : 'Copy' }}
+            </button>
+            <button
+              type="button"
+              class="cg-btn"
+              @click="downloadActive">
+              Download
+            </button>
+          </div>
+        </div>
+
+        <pre
+          class="cg-preview"
+          tabindex="0"><code>{{ activeContent }}</code></pre>
+
+        <p class="cg-note">
+          These fragments contain the options you selected above and layer on
+          top of the shipped defaults. Copy <code>config.yaml</code> /
+          <code>auth.yaml</code> into your <code>etc/</code> directory. Secrets
+          (<code>SECRET</code>, database URLs, credentials) appear only as empty
+          placeholders in the <code>.env</code> tab — set those yourself, and
+          never paste them into a shared link.
+        </p>
+      </section>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+  /* Uses Starlight's CSS custom properties so the tool is theme-aware
+     (light/dark) and matches the surrounding docs chrome. */
+  .cg {
+    margin: 1.5rem 0;
+  }
+  .cg-grid {
+    display: grid;
+    gap: 2rem;
+  }
+  @media (min-width: 60rem) {
+    .cg-grid {
+      grid-template-columns: 1fr 1fr;
+      align-items: start;
+    }
+  }
+  /* Prevent long preview lines from blowing out the grid column: min-width:0
+     lets the column shrink so the <pre> scrolls internally instead. */
+  .cg-options,
+  .cg-output {
+    min-width: 0;
+  }
+
+  .cg-options {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+  .cg-option {
+    border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+    border-radius: 0.5rem;
+    padding: 0.85rem 1rem;
+    background: var(--sl-color-bg-sidebar, transparent);
+  }
+  .cg-option-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+  .cg-option-label {
+    font-weight: 600;
+    color: var(--sl-color-white);
+  }
+  .cg-option-desc {
+    margin: 0.4rem 0 0;
+    font-size: 0.8125rem;
+    color: var(--sl-color-gray-3);
+  }
+  .cg-option-req {
+    margin: 0.35rem 0 0;
+    font-size: 0.8125rem;
+    font-style: italic;
+    color: var(--sl-color-orange-high, #b45309);
+  }
+  .cg-select {
+    margin-top: 0.6rem;
+    width: 100%;
+    padding: 0.45rem 0.6rem;
+    border-radius: 0.375rem;
+    border: 1px solid var(--sl-color-gray-5);
+    background: var(--sl-color-bg);
+    color: var(--sl-color-white);
+    font: inherit;
+  }
+
+  /* Toggle switch */
+  .cg-switch {
+    position: relative;
+    flex: none;
+    width: 2.75rem;
+    height: 1.5rem;
+    border-radius: 9999px;
+    border: none;
+    cursor: pointer;
+    transition: background-color 0.15s;
+    padding: 0;
+  }
+  .cg-switch.on {
+    background: var(--sl-color-accent);
+  }
+  .cg-switch.off {
+    background: var(--sl-color-gray-5);
+  }
+  .cg-switch:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  .cg-knob {
+    position: absolute;
+    top: 0.185rem;
+    left: 0.185rem;
+    width: 1.13rem;
+    height: 1.13rem;
+    border-radius: 9999px;
+    background: #fff;
+    transition: transform 0.15s;
+  }
+  .cg-switch.on .cg-knob {
+    transform: translateX(1.25rem);
+  }
+
+  /* Output */
+  .cg-warnings {
+    margin: 0 0 1rem;
+    padding: 0.6rem 0.9rem 0.6rem 2rem;
+    border: 1px solid var(--sl-color-orange, #d97706);
+    border-radius: 0.5rem;
+    background: var(--sl-color-orange-low, #fef3c7);
+    color: var(--sl-color-orange-high, #92400e);
+    font-size: 0.85rem;
+  }
+  .cg-tabs {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    border-bottom: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+    flex-wrap: wrap;
+  }
+  .cg-tablist {
+    display: flex;
+  }
+  .cg-tab {
+    padding: 0.4rem 0.85rem;
+    border: none;
+    border-bottom: 2px solid transparent;
+    background: none;
+    cursor: pointer;
+    font-family: var(--__sl-font-mono, monospace);
+    font-size: 0.85rem;
+    color: var(--sl-color-gray-2);
+  }
+  .cg-tab.active {
+    color: var(--sl-color-white);
+    border-bottom-color: var(--sl-color-accent);
+  }
+  .cg-actions {
+    display: flex;
+    gap: 0.35rem;
+  }
+  .cg-btn {
+    padding: 0.25rem 0.7rem;
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.375rem;
+    background: var(--sl-color-bg);
+    color: var(--sl-color-white);
+    font-size: 0.8rem;
+    cursor: pointer;
+  }
+  .cg-btn:hover {
+    background: var(--sl-color-gray-6);
+  }
+  .cg-preview {
+    margin: 0.75rem 0 0;
+    max-height: 60vh;
+    overflow: auto;
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.5rem;
+    padding: 0.9rem 1rem;
+    background: var(--sl-color-gray-7, #0d1117);
+    font-size: 0.82rem;
+    line-height: 1.5;
+  }
+  .cg-note {
+    margin-top: 0.75rem;
+    font-size: 0.8rem;
+    color: var(--sl-color-gray-3);
+  }
+</style>

--- a/src/components/config-generator/ConfigGenerator.vue
+++ b/src/components/config-generator/ConfigGenerator.vue
@@ -29,7 +29,6 @@
   } from './generate';
 
   const selections = reactive<Selections>(defaultSelections());
-  const ready = ref(false);
 
   const outputs = [
     { key: 'configYaml' as const, label: 'config.yaml', filename: 'config.yaml' },
@@ -81,7 +80,6 @@
 
   onMounted(() => {
     seedFromUrl();
-    ready.value = true;
     watch(selections, syncUrl, { deep: true });
   });
 
@@ -183,13 +181,13 @@
         <div class="cg-tabs">
           <div
             class="cg-tablist"
-            role="tablist">
+            role="group"
+            aria-label="Generated file">
             <button
               v-for="output in outputs"
               :key="output.key"
               type="button"
-              role="tab"
-              :aria-selected="activeOutput === output.key"
+              :aria-pressed="activeOutput === output.key"
               class="cg-tab"
               :class="{ active: activeOutput === output.key }"
               @click="activeOutput = output.key">
@@ -214,7 +212,8 @@
 
         <pre
           class="cg-preview"
-          tabindex="0"><code>{{ activeContent }}</code></pre>
+          tabindex="0"
+          :aria-label="`${activeMeta.label} preview`"><code>{{ activeContent }}</code></pre>
 
         <p class="cg-note">
           These fragments contain the options you selected above and layer on
@@ -271,7 +270,7 @@
   }
   .cg-option-label {
     font-weight: 600;
-    color: var(--sl-color-white);
+    color: var(--sl-color-text);
   }
   .cg-option-desc {
     margin: 0.4rem 0 0;
@@ -291,7 +290,7 @@
     border-radius: 0.375rem;
     border: 1px solid var(--sl-color-gray-5);
     background: var(--sl-color-bg);
-    color: var(--sl-color-white);
+    color: var(--sl-color-text);
     font: inherit;
   }
 
@@ -363,7 +362,7 @@
     color: var(--sl-color-gray-2);
   }
   .cg-tab.active {
-    color: var(--sl-color-white);
+    color: var(--sl-color-text);
     border-bottom-color: var(--sl-color-accent);
   }
   .cg-actions {
@@ -375,7 +374,7 @@
     border: 1px solid var(--sl-color-gray-5);
     border-radius: 0.375rem;
     background: var(--sl-color-bg);
-    color: var(--sl-color-white);
+    color: var(--sl-color-text);
     font-size: 0.8rem;
     cursor: pointer;
   }

--- a/src/components/config-generator/generate.ts
+++ b/src/components/config-generator/generate.ts
@@ -84,27 +84,25 @@ export function coerce(opt: OptionSpec, raw: unknown): Scalar {
   return match ? match.value : defaultFor(opt);
 }
 
-// Keys that must never be written through a dotted path, to avoid prototype
-// pollution. The paths here come from the hard-coded preset manifest (not user
-// input), so this is defense-in-depth, but it also keeps the generator safe if
-// a path is ever sourced from somewhere less trusted.
-const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
-
+// Reject the dangerous prototype-pollution keys before any property write.
+// The comparison is spelled out inline at each write site (rather than a
+// Set/array lookup) so static analysis recognizes it as a guard on the
+// property name. The paths here come from the hard-coded preset manifest, not
+// user input, so this is defense-in-depth — but it keeps the writer safe
+// regardless of the source.
 function setPath(target: Record<string, unknown>, path: string, value: unknown): void {
   const keys = path.split('.');
 
   let node = target;
   for (let i = 0; i < keys.length - 1; i++) {
     const key = keys[i];
-    // Guard each key immediately before it is used to write, so a __proto__ /
-    // constructor / prototype segment can never reach a property assignment.
-    if (UNSAFE_KEYS.has(key)) return;
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') return;
     if (typeof node[key] !== 'object' || node[key] == null) node[key] = {};
     node = node[key] as Record<string, unknown>;
   }
 
   const lastKey = keys[keys.length - 1];
-  if (UNSAFE_KEYS.has(lastKey)) return;
+  if (lastKey === '__proto__' || lastKey === 'constructor' || lastKey === 'prototype') return;
   node[lastKey] = value;
 }
 

--- a/src/components/config-generator/generate.ts
+++ b/src/components/config-generator/generate.ts
@@ -171,16 +171,23 @@ export function generate(rawSelections: Selections): GenerateResult {
 }
 
 /**
- * Build the .env starter. Secret-bearing vars are always emitted as empty
- * placeholders — the generator never bakes a value that could leak through a
- * shared link or a committed file.
+ * Build the .env starter: the secrets and connection details the selected
+ * options require, emitted as empty placeholders for the operator to fill in.
+ *
+ * Only values the operator must supply themselves appear here — never a
+ * generated value that could leak through a shared link. Feature toggles and
+ * modes are expressed in the config.yaml / auth.yaml above, not here (emitting
+ * e.g. `EMAILER_MODE=` blank would override the setting to an empty string).
+ * SECRET is always required, so it leads the list.
  */
 export function envSnippet(selections: Selections): string {
   const lines = [
-    '# Secrets — generate and store these yourself; never commit them',
-    '# or paste them into a shared link.',
+    '# Secrets and connection details your selections require — fill these in',
+    '# yourself. Never commit the secret values or paste them into a shared',
+    '# link. Feature toggles and modes are in the YAML above, not here.',
+    'SECRET=',
   ];
-  const seen = new Set<string>();
+  const seen = new Set<string>(['SECRET']);
 
   for (const opt of OPTIONS) {
     const value = selections[opt.key];

--- a/src/components/config-generator/generate.ts
+++ b/src/components/config-generator/generate.ts
@@ -1,0 +1,198 @@
+// src/components/config-generator/generate.ts
+//
+// Pure, dependency-light logic for the Configuration Generator. Turns a set of
+// selections into config.yaml / auth.yaml override fragments and a .env starter,
+// entirely client-side — no application backend involved.
+//
+// The vendored JSON schemas (src/components/config-generator/schemas/*.schema.json) are the
+// source of truth for defaults and value constraints; the preset manifest
+// (presets.ts) supplies the curation and the ENV mapping the schemas don't
+// carry. See generateConfig() for how the two combine.
+
+import { stringify } from 'yaml';
+import configStaticSchema from './schemas/config-static.schema.json';
+import configAuthSchema from './schemas/config-auth.schema.json';
+import { OPTIONS, type OptionSpec } from './presets';
+
+type Scalar = string | number | boolean;
+type SchemaNode = Record<string, unknown>;
+
+const SCHEMAS: Record<'config' | 'auth', SchemaNode> = {
+  config: configStaticSchema as SchemaNode,
+  auth: configAuthSchema as SchemaNode,
+};
+
+/** Walk a dotted path through a JSON Schema's nested `properties`. */
+function schemaNodeAt(file: 'config' | 'auth', path: string): SchemaNode | undefined {
+  let node: SchemaNode | undefined = SCHEMAS[file];
+  for (const key of path.split('.')) {
+    const props = node?.properties as Record<string, SchemaNode> | undefined;
+    node = props?.[key];
+    if (!node) return undefined;
+  }
+  return node;
+}
+
+/**
+ * Resolve an option's effective default: the schema default if present,
+ * otherwise the manifest's fallbackDefault. This is what makes the generator
+ * "schema-backed" — the numbers/booleans come from the app's Zod shapes, not
+ * hard-coded copies, wherever the schema exposes them.
+ */
+export function defaultFor(opt: OptionSpec): Scalar {
+  if (opt.schemaPath) {
+    const node = schemaNodeAt(opt.schemaPath.file, opt.schemaPath.path);
+    if (node && 'default' in node && node.default != null) {
+      return node.default as Scalar;
+    }
+  }
+  return opt.fallbackDefault;
+}
+
+/**
+ * Derive select choices from a schema enum when the manifest doesn't spell them
+ * out. (Currently every select declares explicit, human-labelled choices, so
+ * this is a fallback for future options.)
+ */
+export function choicesFor(opt: OptionSpec): Array<{ value: Scalar; label: string }> {
+  if (opt.choices) return opt.choices;
+  if (opt.schemaPath) {
+    const node = schemaNodeAt(opt.schemaPath.file, opt.schemaPath.path);
+    const values = node?.enum as Scalar[] | undefined;
+    if (values) return values.map((v) => ({ value: v, label: String(v) }));
+  }
+  return [];
+}
+
+export type Selections = Record<string, Scalar>;
+
+/** Every option at its effective default. */
+export function defaultSelections(): Selections {
+  const out: Selections = {};
+  for (const opt of OPTIONS) out[opt.key] = defaultFor(opt);
+  return out;
+}
+
+/** Coerce a raw (e.g. URL-query) value to the option's type, or fall back. */
+export function coerce(opt: OptionSpec, raw: unknown): Scalar {
+  if (raw == null) return defaultFor(opt);
+  if (opt.type === 'boolean') {
+    return raw === true || ['true', '1', 'yes'].includes(String(raw).toLowerCase());
+  }
+  const choices = choicesFor(opt);
+  const match = choices.find((c) => String(c.value) === String(raw));
+  return match ? match.value : defaultFor(opt);
+}
+
+function setPath(target: Record<string, unknown>, path: string, value: unknown): void {
+  const keys = path.split('.');
+  let node = target;
+  for (let i = 0; i < keys.length - 1; i++) {
+    const key = keys[i];
+    if (typeof node[key] !== 'object' || node[key] == null) node[key] = {};
+    node = node[key] as Record<string, unknown>;
+  }
+  node[keys[keys.length - 1]] = value;
+}
+
+export interface GenerateResult {
+  configYaml: string;
+  authYaml: string;
+  envSnippet: string;
+  warnings: string[];
+}
+
+/**
+ * A dependent option whose requirement isn't met is reset to its default and a
+ * warning is recorded — never a hard error, so a stale shared link degrades
+ * gracefully.
+ */
+function enforceDependencies(selections: Selections): string[] {
+  const warnings: string[] = [];
+  for (const opt of OPTIONS) {
+    if (!opt.requires) continue;
+    const unmet = Object.entries(opt.requires).some(([dep, val]) => selections[dep] !== val);
+    if (unmet && selections[opt.key] !== defaultFor(opt)) {
+      const req = Object.entries(opt.requires)
+        .map(([k, v]) => `${k}: ${JSON.stringify(v)}`)
+        .join(', ');
+      warnings.push(`${opt.label} requires ${req}; ignoring the selected value.`);
+      selections[opt.key] = defaultFor(opt);
+    }
+  }
+  return warnings;
+}
+
+function dumpFragment(doc: Record<string, unknown>): string {
+  if (Object.keys(doc).length === 0) return '';
+  return stringify(doc);
+}
+
+export function generate(rawSelections: Selections): GenerateResult {
+  // Normalize + coerce every option, ignoring unknown keys.
+  const selections: Selections = {};
+  for (const opt of OPTIONS) selections[opt.key] = coerce(opt, rawSelections[opt.key]);
+
+  const warnings = enforceDependencies(selections);
+
+  const config: Record<string, unknown> = {};
+  const auth: Record<string, unknown> = {};
+
+  for (const opt of OPTIONS) {
+    const value = selections[opt.key];
+    const target = opt.file === 'auth' ? auth : config;
+
+    if (opt.key === 'deployment_mode') {
+      auth.mode = value;
+      continue;
+    }
+    if (opt.key === 'sso_enabled') {
+      // Only meaningful in full mode (enforceDependencies guarantees this).
+      if (selections.deployment_mode === 'full') setPath(auth, 'full.features.sso', value);
+      continue;
+    }
+    if (opt.path) setPath(target, opt.path, value);
+  }
+
+  return {
+    configYaml: dumpFragment(config),
+    authYaml: dumpFragment(auth),
+    envSnippet: envSnippet(selections),
+    warnings,
+  };
+}
+
+/**
+ * Build the .env starter. Secret-bearing vars are always emitted as empty
+ * placeholders — the generator never bakes a value that could leak through a
+ * shared link or a committed file.
+ */
+export function envSnippet(selections: Selections): string {
+  const lines = [
+    '# Secrets — generate and store these yourself; never commit them',
+    '# or paste them into a shared link.',
+  ];
+  const seen = new Set<string>();
+
+  for (const opt of OPTIONS) {
+    const value = selections[opt.key];
+    for (const env of opt.env ?? []) {
+      if (env.when !== undefined && env.when !== value) continue;
+      if (seen.has(env.name)) continue;
+      seen.add(env.name);
+      lines.push(`${env.name}=`);
+    }
+  }
+  return lines.join('\n') + '\n';
+}
+
+/** Selections → shareable URL query (only non-default values, for short links). */
+export function toQuery(selections: Selections): Record<string, string> {
+  const query: Record<string, string> = {};
+  for (const opt of OPTIONS) {
+    const value = selections[opt.key];
+    if (value === defaultFor(opt)) continue;
+    query[opt.key] = String(value);
+  }
+  return query;
+}

--- a/src/components/config-generator/generate.ts
+++ b/src/components/config-generator/generate.ts
@@ -84,8 +84,16 @@ export function coerce(opt: OptionSpec, raw: unknown): Scalar {
   return match ? match.value : defaultFor(opt);
 }
 
+// Keys that must never be written through a dotted path, to avoid prototype
+// pollution. The paths here come from the hard-coded preset manifest (not user
+// input), so this is defense-in-depth, but it also keeps the generator safe if
+// a path is ever sourced from somewhere less trusted.
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 function setPath(target: Record<string, unknown>, path: string, value: unknown): void {
   const keys = path.split('.');
+  if (keys.some((key) => UNSAFE_KEYS.has(key))) return;
+
   let node = target;
   for (let i = 0; i < keys.length - 1; i++) {
     const key = keys[i];

--- a/src/components/config-generator/generate.ts
+++ b/src/components/config-generator/generate.ts
@@ -92,15 +92,20 @@ const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
 function setPath(target: Record<string, unknown>, path: string, value: unknown): void {
   const keys = path.split('.');
-  if (keys.some((key) => UNSAFE_KEYS.has(key))) return;
 
   let node = target;
   for (let i = 0; i < keys.length - 1; i++) {
     const key = keys[i];
+    // Guard each key immediately before it is used to write, so a __proto__ /
+    // constructor / prototype segment can never reach a property assignment.
+    if (UNSAFE_KEYS.has(key)) return;
     if (typeof node[key] !== 'object' || node[key] == null) node[key] = {};
     node = node[key] as Record<string, unknown>;
   }
-  node[keys[keys.length - 1]] = value;
+
+  const lastKey = keys[keys.length - 1];
+  if (UNSAFE_KEYS.has(lastKey)) return;
+  node[lastKey] = value;
 }
 
 export interface GenerateResult {

--- a/src/components/config-generator/presets.ts
+++ b/src/components/config-generator/presets.ts
@@ -93,6 +93,9 @@ export const OPTIONS: OptionSpec[] = [
     ],
     env: [
       { name: 'AUTH_DATABASE_URL', secret: true, when: 'full' },
+      // AUTH_SECRET: independent HMAC key for Rodauth (TOTP, login tokens);
+      // cannot be recovered from SECRET, so full mode must supply it.
+      { name: 'AUTH_SECRET', secret: true, when: 'full' },
       { name: 'ARGON2_SECRET', secret: true, when: 'full' },
     ],
   },

--- a/src/components/config-generator/presets.ts
+++ b/src/components/config-generator/presets.ts
@@ -1,0 +1,206 @@
+// src/components/config-generator/presets.ts
+//
+// Preset manifest for the Configuration Generator.
+//
+// This is the small, hand-authored curation layer the JSON schemas can't
+// provide. The vendored schemas (src/components/config-generator/schemas/*.schema.json) are the
+// source of truth for field *structure, types, defaults, and constraints*; this
+// manifest declares:
+//
+//   1. WHICH handful of fields are the installer-facing choices (the schema
+//      describes hundreds of fields — this picks the fork-in-the-road ones).
+//   2. WHERE each choice writes in config.yaml / auth.yaml (its dotted path).
+//   3. WHICH env vars each choice implies (env mapping lives only in the app's
+//      ERB etc/defaults/*.yaml, never in the schema).
+//
+// Defaults and select choices are read from the schemas at runtime where they
+// exist (see generate.ts); a manifest `fallbackDefault` covers the cases the
+// generated schema omits (e.g. secret_options.default_ttl carries no default in
+// the schema, and site.network.trusted_proxy isn't in the static schema at all).
+
+export type OptionType = 'select' | 'boolean';
+
+export interface Choice {
+  value: string | number;
+  label: string;
+}
+
+export interface OptionSpec {
+  /** Stable key — also the URL query param and the schema-lookup id. */
+  key: string;
+  label: string;
+  description?: string;
+  type: OptionType;
+  /** Which file the value is written to. */
+  file: 'config' | 'auth';
+  /**
+   * Dotted path within that file's document, e.g.
+   * 'site.secret_options.passphrase.required'. When omitted (deployment_mode,
+   * email_provider), a custom applier in generate.ts handles the mapping.
+   */
+  path?: string;
+  /** Dotted path into the vendored schema to read default/constraints from. */
+  schemaPath?: { file: 'config' | 'auth'; path: string };
+  /** Used when the schema has no default for schemaPath (or there is none). */
+  fallbackDefault: string | number | boolean;
+  /** For selects. When omitted, derived from a schema enum where available. */
+  choices?: Choice[];
+  /** Gate this option on another selection (e.g. sso needs full mode). */
+  requires?: Record<string, string | number | boolean>;
+  /** Env vars this choice implies. Rendered as empty placeholders when the
+   *  value is secret-bearing (secret:true) so nothing sensitive is ever baked. */
+  env?: Array<{ name: string; secret?: boolean; when?: string | number | boolean }>;
+}
+
+// Keep TTL choices in lockstep with
+// src/schemas/shapes/config/section/secret_options.ts (ttl_options bounds).
+const TTL_CHOICES: Choice[] = [
+  { value: 300, label: '5 minutes' },
+  { value: 1800, label: '30 minutes' },
+  { value: 3600, label: '1 hour' },
+  { value: 14400, label: '4 hours' },
+  { value: 43200, label: '12 hours' },
+  { value: 86400, label: '1 day' },
+  { value: 259200, label: '3 days' },
+  { value: 604800, label: '7 days' },
+  { value: 1209600, label: '14 days' },
+  { value: 2592000, label: '30 days' },
+];
+
+export const OPTIONS: OptionSpec[] = [
+  {
+    key: 'deployment_mode',
+    label: 'Deployment mode',
+    description:
+      'Simple mode uses Redis/Valkey only, no SQL database. Full mode adds ' +
+      'PostgreSQL-backed accounts, teams, and SSO.',
+    type: 'select',
+    file: 'auth',
+    // path handled by a custom applier (writes auth.mode)
+    schemaPath: { file: 'auth', path: 'mode' },
+    fallbackDefault: 'simple',
+    choices: [
+      { value: 'simple', label: 'Simple — single container, Redis/Valkey only' },
+      { value: 'full', label: 'Full — accounts, teams, SSO (adds PostgreSQL)' },
+    ],
+    env: [
+      { name: 'AUTHENTICATION_MODE' },
+      { name: 'AUTH_DATABASE_URL', secret: true, when: 'full' },
+      { name: 'ARGON2_SECRET', secret: true, when: 'full' },
+    ],
+  },
+  {
+    key: 'email_provider',
+    label: 'Email delivery',
+    description:
+      'How outgoing mail (verification, notifications, password reset) is sent.',
+    type: 'select',
+    file: 'config',
+    path: 'emailer.mode',
+    schemaPath: { file: 'config', path: 'emailer.mode' },
+    fallbackDefault: 'smtp',
+    choices: [
+      { value: 'smtp', label: 'Generic SMTP' },
+      { value: 'ses', label: 'Amazon SES' },
+      { value: 'sendgrid', label: 'SendGrid' },
+      { value: 'lettermint', label: 'Lettermint' },
+    ],
+    env: [
+      { name: 'EMAILER_MODE' },
+      { name: 'SMTP_HOST', when: 'smtp' },
+      { name: 'SMTP_USERNAME', when: 'smtp' },
+      { name: 'SMTP_PASSWORD', secret: true, when: 'smtp' },
+      { name: 'AWS_ACCESS_KEY_ID', secret: true, when: 'ses' },
+      { name: 'AWS_SECRET_ACCESS_KEY', secret: true, when: 'ses' },
+      { name: 'SENDGRID_API_KEY', secret: true, when: 'sendgrid' },
+      { name: 'LETTERMINT_API_TOKEN', secret: true, when: 'lettermint' },
+      { name: 'LETTERMINT_TEAM_TOKEN', secret: true, when: 'lettermint' },
+    ],
+  },
+  {
+    key: 'sso_enabled',
+    label: 'Single sign-on (SSO)',
+    description:
+      'External identity providers via OmniAuth (OIDC, Entra ID, Google, ' +
+      'GitHub). Requires Full deployment mode.',
+    type: 'boolean',
+    file: 'auth',
+    path: 'full.features.sso',
+    fallbackDefault: false,
+    requires: { deployment_mode: 'full' },
+    env: [{ name: 'AUTH_SSO_ENABLED' }],
+  },
+  {
+    key: 'domains_enabled',
+    label: 'Custom domains',
+    description:
+      'Let users share secrets from their own domain instead of the default host.',
+    type: 'boolean',
+    file: 'config',
+    path: 'features.domains.enabled',
+    schemaPath: { file: 'config', path: 'features.domains.enabled' },
+    fallbackDefault: false,
+    env: [{ name: 'DOMAINS_ENABLED' }],
+  },
+  {
+    key: 'regions_enabled',
+    label: 'Multi-region / jurisdictions',
+    description:
+      'Advertise multiple regional deployments for data-residency requirements.',
+    type: 'boolean',
+    file: 'config',
+    path: 'features.regions.enabled',
+    schemaPath: { file: 'config', path: 'features.regions.enabled' },
+    fallbackDefault: false,
+    env: [{ name: 'REGIONS_ENABLED' }],
+  },
+  {
+    key: 'diagnostics_enabled',
+    label: 'Error tracking (Sentry)',
+    description: 'Report backend, frontend, and worker exceptions to Sentry.',
+    type: 'boolean',
+    file: 'config',
+    path: 'diagnostics.enabled',
+    schemaPath: { file: 'config', path: 'diagnostics.enabled' },
+    fallbackDefault: false,
+    env: [
+      { name: 'DIAGNOSTICS_ENABLED' },
+      { name: 'SENTRY_DSN_BACKEND', secret: true, when: true },
+    ],
+  },
+  {
+    key: 'trusted_proxy_enabled',
+    label: 'Behind a reverse proxy / load balancer',
+    description:
+      'Trust X-Forwarded-For from an upstream proxy (nginx, Caddy, ALB, k8s ' +
+      'ingress) when resolving client IPs.',
+    type: 'boolean',
+    file: 'config',
+    path: 'site.network.trusted_proxy.enabled',
+    // NOTE: site.network is not present in the static schema, so there is no
+    // schemaPath — the fallbackDefault is authoritative here.
+    fallbackDefault: false,
+    env: [{ name: 'TRUSTED_PROXY_ENABLED' }],
+  },
+  {
+    key: 'passphrase_required',
+    label: 'Require a passphrase on every secret',
+    type: 'boolean',
+    file: 'config',
+    path: 'site.secret_options.passphrase.required',
+    schemaPath: { file: 'config', path: 'site.secret_options.passphrase.required' },
+    fallbackDefault: false,
+    env: [{ name: 'PASSPHRASE_REQUIRED' }],
+  },
+  {
+    key: 'default_ttl',
+    label: 'Default secret lifetime',
+    type: 'select',
+    file: 'config',
+    path: 'site.secret_options.default_ttl',
+    schemaPath: { file: 'config', path: 'site.secret_options.default_ttl' },
+    fallbackDefault: 604800,
+    choices: TTL_CHOICES,
+    env: [{ name: 'DEFAULT_TTL' }],
+  },
+];

--- a/src/components/config-generator/presets.ts
+++ b/src/components/config-generator/presets.ts
@@ -47,8 +47,16 @@ export interface OptionSpec {
   choices?: Choice[];
   /** Gate this option on another selection (e.g. sso needs full mode). */
   requires?: Record<string, string | number | boolean>;
-  /** Env vars this choice implies. Rendered as empty placeholders when the
-   *  value is secret-bearing (secret:true) so nothing sensitive is ever baked. */
+  /**
+   * Environment variables the operator must supply for this choice — secrets
+   * (database URLs, API keys) and connection details (SMTP host/user). Emitted
+   * as blank placeholders in the .env starter for the operator to fill in.
+   *
+   * Feature toggles and modes are NOT listed here: those are expressed in the
+   * generated config.yaml / auth.yaml, and emitting e.g. `EMAILER_MODE=` blank
+   * would override the setting to an empty string. `secret: true` flags the
+   * values that must never be committed or shared.
+   */
   env?: Array<{ name: string; secret?: boolean; when?: string | number | boolean }>;
 }
 
@@ -84,7 +92,6 @@ export const OPTIONS: OptionSpec[] = [
       { value: 'full', label: 'Full — accounts, teams, SSO (adds PostgreSQL)' },
     ],
     env: [
-      { name: 'AUTHENTICATION_MODE' },
       { name: 'AUTH_DATABASE_URL', secret: true, when: 'full' },
       { name: 'ARGON2_SECRET', secret: true, when: 'full' },
     ],
@@ -106,7 +113,6 @@ export const OPTIONS: OptionSpec[] = [
       { value: 'lettermint', label: 'Lettermint' },
     ],
     env: [
-      { name: 'EMAILER_MODE' },
       { name: 'SMTP_HOST', when: 'smtp' },
       { name: 'SMTP_USERNAME', when: 'smtp' },
       { name: 'SMTP_PASSWORD', secret: true, when: 'smtp' },
@@ -128,7 +134,6 @@ export const OPTIONS: OptionSpec[] = [
     path: 'full.features.sso',
     fallbackDefault: false,
     requires: { deployment_mode: 'full' },
-    env: [{ name: 'AUTH_SSO_ENABLED' }],
   },
   {
     key: 'domains_enabled',
@@ -140,7 +145,6 @@ export const OPTIONS: OptionSpec[] = [
     path: 'features.domains.enabled',
     schemaPath: { file: 'config', path: 'features.domains.enabled' },
     fallbackDefault: false,
-    env: [{ name: 'DOMAINS_ENABLED' }],
   },
   {
     key: 'regions_enabled',
@@ -152,7 +156,6 @@ export const OPTIONS: OptionSpec[] = [
     path: 'features.regions.enabled',
     schemaPath: { file: 'config', path: 'features.regions.enabled' },
     fallbackDefault: false,
-    env: [{ name: 'REGIONS_ENABLED' }],
   },
   {
     key: 'diagnostics_enabled',
@@ -163,10 +166,7 @@ export const OPTIONS: OptionSpec[] = [
     path: 'diagnostics.enabled',
     schemaPath: { file: 'config', path: 'diagnostics.enabled' },
     fallbackDefault: false,
-    env: [
-      { name: 'DIAGNOSTICS_ENABLED' },
-      { name: 'SENTRY_DSN_BACKEND', secret: true, when: true },
-    ],
+    env: [{ name: 'SENTRY_DSN_BACKEND', secret: true, when: true }],
   },
   {
     key: 'trusted_proxy_enabled',
@@ -180,7 +180,6 @@ export const OPTIONS: OptionSpec[] = [
     // NOTE: site.network is not present in the static schema, so there is no
     // schemaPath — the fallbackDefault is authoritative here.
     fallbackDefault: false,
-    env: [{ name: 'TRUSTED_PROXY_ENABLED' }],
   },
   {
     key: 'passphrase_required',
@@ -190,7 +189,6 @@ export const OPTIONS: OptionSpec[] = [
     path: 'site.secret_options.passphrase.required',
     schemaPath: { file: 'config', path: 'site.secret_options.passphrase.required' },
     fallbackDefault: false,
-    env: [{ name: 'PASSPHRASE_REQUIRED' }],
   },
   {
     key: 'default_ttl',
@@ -201,6 +199,5 @@ export const OPTIONS: OptionSpec[] = [
     schemaPath: { file: 'config', path: 'site.secret_options.default_ttl' },
     fallbackDefault: 604800,
     choices: TTL_CHOICES,
-    env: [{ name: 'DEFAULT_TTL' }],
   },
 ];

--- a/src/components/config-generator/schemas/README.md
+++ b/src/components/config-generator/schemas/README.md
@@ -1,0 +1,49 @@
+# Vendored config JSON schemas
+
+These files are **generated artifacts copied from the main application repo**
+([`onetimesecret/onetimesecret`](https://github.com/onetimesecret/onetimesecret)).
+They are the source of truth for config field structure, types, defaults, and
+value constraints, and drive the client-side Configuration Generator
+(`src/components/config-generator/`).
+
+| File | Source (app repo) | Zod origin |
+|---|---|---|
+| `config-static.schema.json` | `generated/schemas/config/static.schema.json` | `src/schemas/shapes/config/config.ts` (`staticConfigShape`) |
+| `config-auth.schema.json` | `generated/schemas/config/auth.schema.json` | `src/schemas/shapes/config/auth.ts` (`authConfigShape`) |
+
+## How to regenerate / re-sync
+
+In a checkout of the app repo:
+
+```sh
+pnpm run schemas:json:generate      # writes generated/schemas/config/*.schema.json
+```
+
+Then copy the two files here (renaming `static` → `config-static`, `auth` →
+`config-auth`) and commit. The app repo's `generated/schemas/` is git-ignored
+(a build artifact), which is why these are vendored rather than imported.
+
+Vendored at app repo commit: `d1840c5`.
+
+## Why vendored (not fetched)
+
+Keeping the rendered schemas in this repo makes the static docs build
+self-contained and reproducible — no network dependency at build time, and the
+generator works in local previews. The trade-off is manual re-sync when the
+config surface changes; the table above records exactly where each file comes
+from. A future `schemas:sync`/drift-check script (or publishing the schemas to a
+stable URL for the docs build to fetch) could automate this — see
+`docs/specs/config-generator.md` in the app repo.
+
+## What the schemas do and don't cover
+
+The generator reads **defaults and constraints** from these schemas where they
+exist. Two things the schemas intentionally do **not** carry, which the
+generator supplies from its own small preset manifest
+(`src/components/config-generator/presets.ts`):
+
+- **ENV-var mapping** — which environment variable backs each config key lives
+  only in the app's ERB `etc/defaults/*.yaml`, not the schema.
+- **Presets / curation** — the schema describes the whole config surface
+  (hundreds of fields); the manifest picks the handful of installer-facing
+  choices and how each maps to config keys.

--- a/src/components/config-generator/schemas/config-auth.schema.json
+++ b/src/components/config-generator/schemas/config-auth.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://onetimesecret.com/schemas/config/auth.schema.json",
+  "type": "object",
+  "properties": {
+    "mode": {
+      "default": "simple",
+      "type": "string",
+      "enum": [
+        "simple",
+        "full"
+      ]
+    },
+    "simple": {
+      "type": "object",
+      "properties": {
+        "password_hash_cost": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
+        "session_timeout": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        }
+      }
+    },
+    "full": {
+      "type": "object",
+      "properties": {
+        "database_url": {
+          "default": "sqlite://data/auth.db",
+          "type": "string"
+        },
+        "database_url_migrations": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "service_url": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/src/components/config-generator/schemas/config-static.schema.json
+++ b/src/components/config-generator/schemas/config-static.schema.json
@@ -1,0 +1,1278 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://onetimesecret.com/schemas/config/static.schema.json",
+  "type": "object",
+  "properties": {
+    "site": {
+      "type": "object",
+      "properties": {
+        "host": {
+          "default": "localhost:3000",
+          "type": "string"
+        },
+        "ssl": {
+          "default": false,
+          "type": "boolean"
+        },
+        "secret": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "interface": {},
+        "secret_options": {
+          "type": "object",
+          "properties": {
+            "default_ttl": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "ttl_options": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "generated_value_display_ttl": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            },
+            "passphrase": {
+              "type": "object",
+              "properties": {
+                "required": {
+                  "default": false,
+                  "type": "boolean"
+                },
+                "minimum_length": {
+                  "default": 4,
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 256
+                },
+                "maximum_length": {
+                  "default": 128,
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "enforce_complexity": {
+                  "default": false,
+                  "type": "boolean"
+                }
+              }
+            },
+            "password_generation": {
+              "type": "object",
+              "properties": {
+                "default_length": {
+                  "default": 12,
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "character_sets": {
+                  "type": "object",
+                  "properties": {
+                    "uppercase": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "lowercase": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "numbers": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "symbols": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "exclude_ambiguous": {
+                      "default": true,
+                      "type": "boolean"
+                    }
+                  }
+                }
+              },
+              "required": [
+                "character_sets"
+              ]
+            }
+          },
+          "required": [
+            "passphrase",
+            "password_generation"
+          ]
+        },
+        "authentication": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "default": true,
+              "type": "boolean"
+            },
+            "signup": {
+              "default": true,
+              "type": "boolean"
+            },
+            "signin": {
+              "default": true,
+              "type": "boolean"
+            },
+            "autoverify": {
+              "default": false,
+              "type": "boolean"
+            },
+            "required": {
+              "default": false,
+              "type": "boolean"
+            },
+            "colonels": {
+              "default": [],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "allowed_signup_domains": {
+              "default": [],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "support": {
+          "type": "object",
+          "properties": {
+            "host": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        "session": {
+          "type": "object",
+          "properties": {
+            "secret": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "expire_after": {
+              "default": 86400,
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            },
+            "key": {
+              "default": "onetime.session",
+              "type": "string"
+            },
+            "secure": {
+              "default": true,
+              "type": "boolean"
+            },
+            "same_site": {
+              "default": "lax",
+              "type": "string",
+              "enum": [
+                "strict",
+                "lax",
+                "none"
+              ]
+            },
+            "httponly": {
+              "default": true,
+              "type": "boolean"
+            }
+          }
+        },
+        "middleware": {
+          "type": "object",
+          "properties": {
+            "static_files": {
+              "default": true,
+              "type": "boolean"
+            },
+            "utf8_sanitizer": {
+              "default": true,
+              "type": "boolean"
+            },
+            "authenticity_token": {
+              "default": true,
+              "type": "boolean"
+            },
+            "http_origin": {
+              "default": false,
+              "type": "boolean"
+            },
+            "xss_header": {
+              "default": false,
+              "type": "boolean"
+            },
+            "frame_options": {
+              "default": false,
+              "type": "boolean"
+            },
+            "path_traversal": {
+              "default": false,
+              "type": "boolean"
+            },
+            "cookie_tossing": {
+              "default": false,
+              "type": "boolean"
+            },
+            "ip_spoofing": {
+              "default": false,
+              "type": "boolean"
+            },
+            "strict_transport": {
+              "default": false,
+              "type": "boolean"
+            }
+          }
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "csp": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "default": false,
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "features": {
+      "type": "object",
+      "properties": {
+        "regions": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "type": "boolean"
+            },
+            "current_jurisdiction": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "jurisdictions": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "identifier": {
+                        "type": "string"
+                      },
+                      "display_name": {
+                        "type": "string"
+                      },
+                      "domain": {
+                        "type": "string"
+                      },
+                      "icon": {
+                        "type": "object",
+                        "properties": {
+                          "collection": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        "incoming": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "type": "boolean"
+            },
+            "memo_max_length": {
+              "default": 50,
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            },
+            "default_ttl": {
+              "default": 604800,
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            },
+            "default_passphrase": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "recipients": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "array",
+                    "prefixItems": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "domains": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "type": "boolean"
+            },
+            "require_verified": {
+              "default": false,
+              "type": "boolean"
+            },
+            "default": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "validation_strategy": {
+              "default": "passthrough",
+              "type": "string",
+              "enum": [
+                "passthrough",
+                "approximated",
+                "caddy_on_demand"
+              ]
+            },
+            "approximated": {
+              "type": "object",
+              "properties": {
+                "api_key": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "proxy_ip": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "proxy_host": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "proxy_name": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "vhost_target": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            },
+            "acme": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "default": false,
+                  "type": "boolean"
+                },
+                "listen_address": {
+                  "default": "127.0.0.1",
+                  "type": "string"
+                },
+                "port": {
+                  "default": "12020",
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "redis": {
+      "type": "object",
+      "properties": {
+        "uri": {
+          "default": "redis://127.0.0.1:6379",
+          "type": "string"
+        },
+        "dbs": {
+          "type": "object",
+          "properties": {
+            "session": {
+              "default": 0,
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 15
+            },
+            "custom_domain": {
+              "default": 0,
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 15
+            },
+            "customer": {
+              "default": 0,
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 15
+            },
+            "metadata": {
+              "default": 0,
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 15
+            },
+            "secret": {
+              "default": 0,
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 15
+            },
+            "feedback": {
+              "default": 0,
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 15
+            }
+          }
+        }
+      }
+    },
+    "emailer": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "default": "smtp",
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "from": {
+          "default": "CHANGEME@example.com",
+          "type": "string"
+        },
+        "from_name": {
+          "default": "Support",
+          "type": "string"
+        },
+        "reply_to": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "host": {
+          "default": "smtp.provider.com",
+          "type": "string"
+        },
+        "port": {
+          "default": 587,
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
+        "user": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pass": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "auth": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tls": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "mail": {
+      "type": "object",
+      "properties": {
+        "truemail": {
+          "type": "object",
+          "properties": {
+            "default_validation_type": {
+              "default": ":regex",
+              "type": "string"
+            },
+            "verifier_email": {
+              "default": "CHANGEME@example.com",
+              "type": "string"
+            },
+            "verifier_domain": {
+              "type": "string"
+            },
+            "connection_timeout": {
+              "type": "number"
+            },
+            "response_timeout": {
+              "type": "number"
+            },
+            "connection_attempts": {
+              "type": "number"
+            },
+            "validation_type_for": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "allowed_domains_only": {
+              "default": false,
+              "type": "boolean"
+            },
+            "allowed_emails": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "blocked_emails": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "allowed_domains": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "blocked_domains": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "blocked_mx_ip_addresses": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "dns": {
+              "default": [
+                "1.1.1.1",
+                "8.8.4.4",
+                "208.67.220.220"
+              ],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "smtp_port": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            },
+            "smtp_fail_fast": {
+              "default": false,
+              "type": "boolean"
+            },
+            "smtp_safe_check": {
+              "default": true,
+              "type": "boolean"
+            },
+            "not_rfc_mx_lookup_flow": {
+              "default": false,
+              "type": "boolean"
+            },
+            "email_pattern": {
+              "type": "string"
+            },
+            "smtp_error_body_pattern": {
+              "type": "string"
+            },
+            "logger": {
+              "type": "object",
+              "properties": {
+                "tracking_event": {
+                  "default": ":error",
+                  "type": "string"
+                },
+                "stdout": {
+                  "default": true,
+                  "type": "boolean"
+                },
+                "log_absolute_path": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "jobs": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "rabbitmq_url": {
+          "default": "amqp://guest:guest@localhost:5672/dev",
+          "type": "string"
+        },
+        "channel_pool_size": {
+          "default": 5,
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
+        "fallback_to_sync": {
+          "default": true,
+          "type": "boolean"
+        },
+        "workers": {
+          "type": "object",
+          "properties": {
+            "email": {
+              "default": {
+                "threads": 4,
+                "prefetch": 10
+              },
+              "type": "object",
+              "properties": {
+                "threads": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "prefetch": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                }
+              },
+              "required": [
+                "threads",
+                "prefetch"
+              ]
+            },
+            "notifications": {
+              "default": {
+                "threads": 2,
+                "prefetch": 10
+              },
+              "type": "object",
+              "properties": {
+                "threads": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "prefetch": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                }
+              },
+              "required": [
+                "threads",
+                "prefetch"
+              ]
+            },
+            "billing": {
+              "default": {
+                "threads": 2,
+                "prefetch": 5
+              },
+              "type": "object",
+              "properties": {
+                "threads": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "prefetch": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                }
+              },
+              "required": [
+                "threads",
+                "prefetch"
+              ]
+            }
+          }
+        },
+        "scheduler": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "type": "boolean"
+            }
+          }
+        },
+        "plan_cache_refresh_enabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "catalog_retry_enabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "dlq_consumer_enabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "domain_refresh": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "type": "boolean"
+            },
+            "check_interval": {
+              "default": "30m",
+              "type": "string"
+            },
+            "batch_size": {
+              "default": 200,
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            },
+            "rate_limit": {
+              "default": 0.5,
+              "type": "number",
+              "minimum": 0
+            }
+          }
+        },
+        "expiration_warnings": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "type": "boolean"
+            },
+            "check_interval": {
+              "default": "1h",
+              "type": "string"
+            },
+            "warning_hours": {
+              "default": 24,
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            },
+            "min_ttl_hours": {
+              "default": 48,
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            },
+            "batch_size": {
+              "default": 100,
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            }
+          }
+        },
+        "maintenance": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "type": "boolean"
+            },
+            "phantom_cleanup": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "default": false,
+                  "type": "boolean"
+                },
+                "interval": {
+                  "default": "1h",
+                  "type": "string"
+                },
+                "batch_size": {
+                  "default": 500,
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "auto_repair": {
+                  "default": false,
+                  "type": "boolean"
+                }
+              }
+            },
+            "data_audit": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "default": false,
+                  "type": "boolean"
+                },
+                "interval": {
+                  "default": "6h",
+                  "type": "string"
+                },
+                "sample_size": {
+                  "default": 100,
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                }
+              }
+            },
+            "participation_gc": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "default": false,
+                  "type": "boolean"
+                },
+                "cron": {
+                  "default": "0 5 * * *",
+                  "type": "string"
+                },
+                "batch_size": {
+                  "default": 500,
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "auto_repair": {
+                  "default": false,
+                  "type": "boolean"
+                }
+              }
+            },
+            "index_rebuild": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "default": false,
+                  "type": "boolean"
+                },
+                "cron": {
+                  "default": "0 4 * * *",
+                  "type": "string"
+                },
+                "auto_repair": {
+                  "default": false,
+                  "type": "boolean"
+                }
+              }
+            },
+            "instances_rebuild": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "default": false,
+                  "type": "boolean"
+                },
+                "cron": {
+                  "default": "0 3 * * 0",
+                  "type": "string"
+                },
+                "auto_repair": {
+                  "default": false,
+                  "type": "boolean"
+                }
+              }
+            },
+            "housekeeping": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "default": false,
+                  "type": "boolean"
+                },
+                "cron": {
+                  "default": "0 2 * * *",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "internationalization": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "default_locale": {
+          "default": "en",
+          "type": "string"
+        },
+        "fallback_locale": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "locales": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "incomplete": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "date_format": {
+          "default": "locale",
+          "type": "string"
+        },
+        "datetime_format": {
+          "default": "locale",
+          "type": "string"
+        }
+      },
+      "required": [
+        "fallback_locale"
+      ]
+    },
+    "diagnostics": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "sentry": {
+          "type": "object",
+          "properties": {
+            "defaults": {
+              "type": "object",
+              "properties": {
+                "dsn": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "sampleRate": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                },
+                "maxBreadcrumbs": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                },
+                "logErrors": {
+                  "default": true,
+                  "type": "boolean"
+                }
+              }
+            },
+            "backend": {
+              "type": "object",
+              "properties": {
+                "dsn": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "sampleRate": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                },
+                "maxBreadcrumbs": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                },
+                "logErrors": {
+                  "default": true,
+                  "type": "boolean"
+                }
+              }
+            },
+            "frontend": {
+              "type": "object",
+              "properties": {
+                "dsn": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "sampleRate": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                },
+                "maxBreadcrumbs": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                },
+                "logErrors": {
+                  "default": true,
+                  "type": "boolean"
+                },
+                "trackComponents": {
+                  "default": true,
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "development": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "debug": {
+          "default": false,
+          "type": "boolean"
+        },
+        "frontend_host": {
+          "default": "http://localhost:5173",
+          "type": "string"
+        },
+        "domain_context_enabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "allow_nil_global_secret": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    }
+  },
+  "required": [
+    "site"
+  ]
+}

--- a/src/content/docs/en/self-hosting/configuration.md
+++ b/src/content/docs/en/self-hosting/configuration.md
@@ -9,7 +9,7 @@ sidebar:
 This comprehensive guide covers all configuration options for self-hosted Onetime Secret instances.
 
 :::tip[Try the Configuration Generator]
-Not sure where to start? The in-app **[Configuration Generator](https://onetimesecret.com/configure)** lets you pick a few preset options (deployment mode, email delivery, SSO, custom domains, and more) and copies out ready-to-use `etc/config.yaml` and `etc/auth.yaml` fragments plus a matching `.env` starter. Self-hosted instances expose it at `/configure` on their own domain.
+Not sure where to start? The **[Configuration Generator](/en/self-hosting/configuration-generator/)** lets you pick a few preset options (deployment mode, email delivery, SSO, custom domains, and more) and copies out ready-to-use `etc/config.yaml` and `etc/auth.yaml` fragments plus a matching `.env` starter — all generated in your browser from the config schemas.
 :::
 
 ## Configuration Files

--- a/src/content/docs/en/self-hosting/configuration.md
+++ b/src/content/docs/en/self-hosting/configuration.md
@@ -8,6 +8,10 @@ sidebar:
 
 This comprehensive guide covers all configuration options for self-hosted Onetime Secret instances.
 
+:::tip[Try the Configuration Generator]
+Not sure where to start? The in-app **[Configuration Generator](https://onetimesecret.com/configure)** lets you pick a few preset options (deployment mode, email delivery, SSO, custom domains, and more) and copies out ready-to-use `etc/config.yaml` and `etc/auth.yaml` fragments plus a matching `.env` starter. Self-hosted instances expose it at `/configure` on their own domain.
+:::
+
 ## Configuration Files
 
 Onetime Secret uses multiple configuration files:

--- a/src/content/docs/en/self-hosting/environment-variables.md
+++ b/src/content/docs/en/self-hosting/environment-variables.md
@@ -7,6 +7,9 @@ sidebar:
 
 This guide covers all environment variables available in Onetime Secret v0.24+.
 
+:::tip[Generate a starter config]
+The in-app **[Configuration Generator](https://onetimesecret.com/configure)** produces a matching `.env` starter (with secret-bearing variables left blank for you to fill in) alongside `config.yaml` / `auth.yaml` fragments, based on a few preset choices. Self-hosted instances expose it at `/configure`.
+:::
 
 ## Environment Variables
 

--- a/src/content/docs/en/self-hosting/environment-variables.md
+++ b/src/content/docs/en/self-hosting/environment-variables.md
@@ -8,7 +8,7 @@ sidebar:
 This guide covers all environment variables available in Onetime Secret v0.24+.
 
 :::tip[Generate a starter config]
-The in-app **[Configuration Generator](https://onetimesecret.com/configure)** produces a matching `.env` starter (with secret-bearing variables left blank for you to fill in) alongside `config.yaml` / `auth.yaml` fragments, based on a few preset choices. Self-hosted instances expose it at `/configure`.
+The **[Configuration Generator](/en/self-hosting/configuration-generator/)** produces a matching `.env` starter (with secret-bearing variables left blank for you to fill in) alongside `config.yaml` / `auth.yaml` fragments, based on a few preset choices — generated in your browser from the config schemas.
 :::
 
 ## Environment Variables

--- a/src/content/i18n/en.json
+++ b/src/content/i18n/en.json
@@ -49,6 +49,7 @@
     "regionUS": "United States (US)",
     "selfHosting": "Self-Hosting",
     "configurationReference": "Configuration Reference",
+    "configurationGenerator": "Configuration Generator",
     "installationDeployment": "Installation & Deployment",
     "configuration": "Configuration",
     "coreConfig": "Core Configuration",

--- a/src/pages/en/self-hosting/configuration-generator.astro
+++ b/src/pages/en/self-hosting/configuration-generator.astro
@@ -1,0 +1,36 @@
+---
+// src/pages/en/self-hosting/configuration-generator.astro
+//
+// Hosts the client-side Configuration Generator island inside the standard
+// Starlight docs chrome (sidebar, header, TOC). The tool itself is a self-
+// contained Vue component that reads the vendored config JSON schemas and a
+// preset manifest to generate config.yaml / auth.yaml / .env entirely in the
+// browser — no dependency on the running application.
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+import ConfigGenerator from '../../../components/config-generator/ConfigGenerator.vue';
+
+const title = 'Configuration Generator';
+const description =
+  'Pick a few preset options and copy out ready-to-use config.yaml, auth.yaml, ' +
+  'and .env fragments for your self-hosted Onetime Secret instance.';
+---
+
+<StarlightPage
+  frontmatter={{
+    title,
+    description,
+    tableOfContents: false,
+    lastUpdated: false,
+  }}>
+  <p>
+    Choose the options that fit your deployment and copy the generated YAML into
+    your <code>etc/</code> directory. These fragments layer on top of the shipped
+    defaults, so you only need the options shown here. For the full option
+    surface, see the
+    <a href="/en/self-hosting/configuration/">Configuration Reference</a> and
+    <a href="/en/self-hosting/environment-variables/">Environment Variables</a>
+    pages.
+  </p>
+
+  <ConfigGenerator client:load />
+</StarlightPage>


### PR DESCRIPTION
## Summary

Adds a **Configuration Generator** to the docs site: a self-contained, client-side tool that turns a handful of preset choices into ready-to-use `etc/config.yaml` / `etc/auth.yaml` override fragments plus a companion `.env` starter. It runs entirely in the browser and is driven by the config JSON schemas — no dependency on a running application.

It's inspired by Caddy's download builder and Fly.io's first-deploy picker: configure in the browser, copy the result, continue on the command line. Selections mirror into the URL for shareable links; secret-bearing vars appear only as empty `.env` placeholders.

## Changes

**Generator island** (`src/components/config-generator/`)
- `schemas/` — the config JSON schemas (`config-static`, `config-auth`) vendored from the app repo's generated output, with a `README.md` recording provenance and how to re-sync. Source of truth for defaults/constraints.
- `presets.ts` — a small preset manifest for the curated option set and the ENV-var mapping the schemas don't carry (which env var backs each key lives in the app's ERB defaults, not the schema).
- `generate.ts` — reads defaults/constraints from the schemas, applies the presets, and produces the YAML/`.env` client-side via the `yaml` package. Same forgiving coercion + dependency rules as the app's JSON API.
- `ConfigGenerator.vue` — the UI island: form controls, live preview with per-file tabs, copy/download, URL sync. Theme-aware via Starlight CSS variables.

**Page + nav**
- `src/pages/en/self-hosting/configuration-generator.astro` hosts the island in standard Starlight chrome via `<StarlightPage>`.
- Sidebar (`config/sidebar.mjs`) + `en.json`: a "Configuration Generator" entry under Self-Hosting, between Configuration Reference and Environment Variables.

**Callouts**
- `configuration.md` / `environment-variables.md`: tip boxes now link to the internal `/en/self-hosting/configuration-generator/` page (the earlier revision linked to `onetimesecret.com/configure`, which is the marketing site — not a running app).

## Design notes

- Schemas provide structure/defaults/constraints; the preset manifest supplies curation and ENV mapping. Two things the schemas can't cover (ENV mapping, "presets") are the manifest's job — documented in `schemas/README.md`.
- Schemas are vendored (not fetched at build) so the static build stays self-contained and reproducible; a drift-check / publish step is noted as a follow-up.

## Test plan

- `pnpm build` green (1052 pages); the generator page and island bundle correctly.
- Live browser test (built output): schema defaults resolve, YAML updates live, dependency gating works (SSO only in full mode), secrets stay blank, URL sync produces a shareable link, zero console errors.
- `astro check`: no errors in any new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSoV5aLqCLxuSqemm8ymJ4