### PR TITLE
Enable Pagefind search; BunnyCDN deploy cutover + staging markers

### DIFF
--- a/config/starlight.mjs
+++ b/config/starlight.mjs
@@ -32,7 +32,7 @@ export const starlightConfig = {
     alt: "Onetime Secret",
     replacesTitle: true,
   },
-  pagefind: false,
+  pagefind: true,
   plugins: [],
 
   // Prerelease only: keep the staging/preview deploy out of search engines.


### PR DESCRIPTION
## Summary

Enables Pagefind site search and lands the supporting infra that had been staged on `develop` but not yet on `main`: the BunnyCDN deploy cutover and the staging banner/watermark environment markers.

## Changes

### Search
- Flip the Pagefind flag to `true` in `config/starlight.mjs` — enables client-side search across all 17 locales (UI strings already present in every `i18n/*.json`).

### Deploy (BunnyCDN cutover)
- Replace `deploy-production.yml` / `deploy-staging.yml` with a single `deploy.yml` triggered on both `develop` and `main`, selecting environment by branch.
- Add `ci.yml`; tidy `check-links.yml`, `claude*.yml`, `validate-json.yml`.

### Staging markers
- `StagingBanner.astro`, `StagingWatermark.astro`, `PageFrame.astro` override, `staging.css` — prerelease banner + watermark, gated by independent flags with `noindex` for non-production environments.
- `config/domains.mjs` + `content.config.ts` — env/domain config backing the markers.
- One banner string added per locale (`i18n/*.json`).

## Note on scope

The branch name says "add-search," but it also carries the deploy-workflow cutover and staging markers (they were bundled on the source branch). Flagging in case you'd prefer to split search from infra before merge.
