### PR TITLE
docs: add comprehensive documentation audit for August 2026

### DIFF
--- a/docs/planning/documentation-audit-2026-08-topics.md
+++ b/docs/planning/documentation-audit-2026-08-topics.md
@@ -1,0 +1,333 @@
+# Documentation audit — full topic inventory
+
+Companion to [`documentation-audit-2026-08.md`](./documentation-audit-2026-08.md). Every catalogued
+feature that is **undocumented** or only **partially** documented on the docs site, grouped by the
+domain that was surveyed.
+
+Tags: `[priority/status]` — priority is `crit` / `high` / `medi` / `low`; status is `undocu`
+(absent from `en/` entirely) or `partia` (mentioned but not usable from the docs alone). Trailing
+identifiers are the environment variables the topic covers, truncated to four.
+
+Fully-documented features are omitted. 304 topics follow.
+
+### Secrets, cryptography & key management
+- [crit/partia] SECRET as root input keying material (IKM) — the HKDF key tree — SECRET
+- [crit/partia] Three key classes: [derived] vs [independent] vs [federation] — SESSION_SECRET,IDENTIFIER_SECRET,AUTH_SECRET,ARGON2_SECRET
+- [crit/undocu] Key generation: `rake ots:secrets` / `bin/setup --init` — ENV_FILE,DERIVE,FORCE
+- [crit/undocu] Boot-time SECRET verifier and SECRET_VERIFIER_MODE (warn / enforce / off) — SECRET_VERIFIER_MODE
+- [crit/undocu] SECRET_PREVIOUS — decrypt-only key rotation chain — SECRET_PREVIOUS
+- [crit/undocu] ACCOUNT_ID_SECRET — account-ID obfuscation (required in production) — ACCOUNT_ID_SECRET
+- [high/undocu] Rotation verification tooling: `rake ots:secrets:verify` / `:adopt` — CONFIRM
+- [high/undocu] Fail-safe reveal under a wrong or missing key (503 `secret_undecryptable`)
+- [high/partia] AUTH_SECRET and AUTH_OLD_SECRET (Rodauth HMAC rotation window) — AUTH_SECRET,AUTH_OLD_SECRET
+- [high/partia] ARGON2_SECRET — Argon2id password pepper — ARGON2_SECRET
+- [high/partia] ALLOW_NIL_GLOBAL_SECRET — nil-secret recovery escape hatch — ALLOW_NIL_GLOBAL_SECRET
+- [high/partia] TTL_OPTIONS — the expiration menu offered to users — TTL_OPTIONS
+- [high/partia] TTL_MAX_ANONYMOUS — expiration ceiling for account-less secrets — TTL_MAX_ANONYMOUS,PLAN_TTL_ANONYMOUS
+- [high/partia] Passphrase policy: required, minimum/maximum length, complexity — PASSPHRASE_REQUIRED,PASSPHRASE_MIN_LENGTH,PASSPHRASE_MAX_LENGTH,PASSPHRASE_ENFORCE_COMPLEXITY
+- [high/undocu] Passphrase brute-force protection (two-tier rate limiting and lockout)
+- [high/undocu] Secret content size limit (SECRET_MAX_LENGTH) — SECRET_MAX_LENGTH
+- [high/partia] One-time reveal of a generated password on the receipt page (GENERATED_VALUE_DISPLAY_TTL) — GENERATED_VALUE_DISPLAY_TTL
+- [high/undocu] The receipt page — the creator's private link and its capabilities — API_GUEST_RECEIPT,UI_CAPABILITIES_RECEIPT
+- [medi/partia] SESSION_SECRET — Rack session signing key — SESSION_SECRET
+- [medi/partia] IDENTIFIER_SECRET and the VERIFIABLE_ID_HMAC_SECRET fallback chain — IDENTIFIER_SECRET,VERIFIABLE_ID_HMAC_SECRET
+- [medi/partia] FEDERATION_SECRET — cross-region shared key — FEDERATION_SECRET
+- [medi/undocu] Fail-fast boot when SECRET is missing or 'CHANGEME' — SECRET
+- [medi/undocu] Encryption parameter pinning (personalization and HKDF salt)
+- [medi/undocu] Passphrase storage: argon2id hashing, unrecoverable by design
+- [medi/partia] Password generation settings (length, character sets, ambiguous characters) — PASSWORD_GEN_LENGTH,PASSWORD_GEN_UPPERCASE,PASSWORD_GEN_LOWERCASE,PASSWORD_GEN_NUMBERS
+- [medi/undocu] PASSWORD_GEN_MAX_LENGTH — server-side generated-password length ceiling — PASSWORD_GEN_MAX_LENGTH
+- [medi/partia] At-most-once reveal guarantee (fail-closed, not fail-open)
+- [medi/undocu] Uniform 'no longer available' response — the deliberate absence of an existence oracle
+- [medi/undocu] Reads are state-neutral: viewing does not reset expiration or advance state
+- [low/undocu] RODAUTH_HMAC_SECRET — deprecated and silently ignored — RODAUTH_HMAC_SECRET
+- [low/undocu] SECRET_VARIABLE_NAMES — routing secrets to Podman/container secret stores — SECRET_VARIABLE_NAMES
+
+### HTTP security, sessions, middleware & network
+- [crit/undocu] Trusted proxy configuration / client IP resolution — TRUSTED_PROXY_ENABLED,TRUSTED_PROXY_MODE,TRUSTED_PROXY_HEADER,TRUSTED_PROXY_CIDRS
+- [crit/undocu] filter vs depth mode and the X-Forwarded-For overwrite requirement — TRUSTED_PROXY_MODE,TRUSTED_PROXY_DEPTH,TRUSTED_PROXY_CIDRS
+- [crit/undocu] ASSUME_HTTPS — origin scheme upgrade behind a non-scheme-forwarding TLS proxy — ASSUME_HTTPS
+- [crit/partia] Session cookie Secure flag — production default and silent cookie drop — SSL,SESSION_SECRET
+- [crit/undocu] Account-creation rate limiter (signup throttle) — CREATE_ACCOUNT_RATE_LIMIT_ENABLED,CREATE_ACCOUNT_RATE_LIMIT_MAX_PER_IP,CREATE_ACCOUNT_RATE_LIMIT_WINDOW,CREATE_ACCOUNT_RATE_LIMIT_LOCKOUT
+- [high/undocu] Password-reset request rate limiter — RESET_REQUEST_RATE_LIMIT_ENABLED,RESET_REQUEST_RATE_LIMIT_MAX_PER_IP,RESET_REQUEST_RATE_LIMIT_MAX_PER_EMAIL,RESET_REQUEST_RATE_LIMIT_WINDOW
+- [high/undocu] Non-configurable perimeter rate limiters (login, passphrase, feedback, invite tokens, DNS verification)
+- [high/undocu] 429 responses and the Retry-After header
+- [high/undocu] Rate-limit inspection and reset (operator recovery from a stuck lockout)
+- [high/undocu] Client IP privacy masking (/24 IPv4, /48 IPv6)
+- [high/undocu] Colonel admin network isolation (ADMIN_ALLOWED_CIDRS) — ADMIN_ALLOWED_CIDRS
+- [high/partia] Health endpoint access control (HEALTH_TRUSTED_CIDR) — HEALTH_TRUSTED_CIDR
+- [high/undocu] IP bans (BannedIP middleware, Colonel API and CLI)
+- [high/partia] Content-Security-Policy with per-request nonce (CSP_ENABLED) — CSP_ENABLED
+- [high/undocu] CSP form-action origins for SSO redirects (SSO_FORM_ACTION_ORIGINS) — SSO_FORM_ACTION_ORIGINS
+- [high/partia] CSRF protection (shrimp authenticity token) and the X-CSRF-Token response header — MIDDLEWARE_AUTHENTICITY_TOKEN
+- [high/undocu] HSTS / Strict-Transport-Security middleware — MIDDLEWARE_STRICT_TRANSPORT
+- [high/undocu] Security middleware toggle matrix (site.middleware.*) — MIDDLEWARE_STATIC_FILES,MIDDLEWARE_UTF8_SANITIZER,MIDDLEWARE_AUTHENTICITY_TOKEN,MIDDLEWARE_HTTP_ORIGIN
+- [high/partia] Homepage-mode CIDR matching depends on global trusted-proxy config — UI_HOMEPAGE_MATCHING_CIDRS,UI_HOMEPAGE_MODE,UI_HOMEPAGE_MODE_HEADER
+- [medi/undocu] Origin-header CSRF protection (MIDDLEWARE_HTTP_ORIGIN) — MIDDLEWARE_HTTP_ORIGIN
+- [medi/partia] Clickjacking protection (X-Frame-Options) — MIDDLEWARE_FRAME_OPTIONS
+- [medi/partia] Legacy XSS header and X-Content-Type-Options nosniff (MIDDLEWARE_XSS_HEADER) — MIDDLEWARE_XSS_HEADER
+- [medi/undocu] Request sanitization middleware (UTF-8 sanitizer, path traversal, cookie tossing, IP spoofing) — MIDDLEWARE_UTF8_SANITIZER,MIDDLEWARE_PATH_TRAVERSAL,MIDDLEWARE_COOKIE_TOSSING,MIDDLEWARE_IP_SPOOFING
+- [medi/undocu] Built-in static asset serving (MIDDLEWARE_STATIC_FILES) — MIDDLEWARE_STATIC_FILES
+- [medi/partia] Session store, lifetime and cookie attributes — SESSION_SECRET
+- [medi/undocu] Incoming-secrets submission rate limiter — INCOMING_RATE_LIMIT_ENABLED,INCOMING_RATE_LIMIT_MAX_PER_IP,INCOMING_RATE_LIMIT_MAX_PER_RECIPIENT,INCOMING_RATE_LIMIT_WINDOW
+- [low/undocu] Request correlation ID (X-Request-Id)
+- [low/undocu] Startup readiness gate (503 before the app is configured)
+- [low/undocu] Content-Type normalization for malformed clients
+
+### Authentication & identity
+- [crit/undocu] ACCOUNT_ID_SECRET (account-id obfuscation) — ACCOUNT_ID_SECRET
+- [crit/undocu] Migrating existing Redis accounts into the auth database (bin/ots customers sync-auth-accounts)
+- [crit/partia] Auth database backend: SQLite vs PostgreSQL (AUTH_DATABASE_URL) — AUTH_DATABASE_URL
+- [crit/partia] TOTP / MFA with recovery codes — AUTH_MFA_ENABLED
+- [crit/partia] SSO master switch and platform provider registration (OIDC, Entra ID, Google, GitHub) — AUTH_SSO_ENABLED,OIDC_ISSUER,OIDC_CLIENT_ID,OIDC_CLIENT_SECRET
+- [crit/undocu] SSO identity linking policy and the trusted-IdP flag — SSO_TRUST_EMAIL_FOR_LINKING,OIDC_TRUST_EMAIL_FOR_LINKING,ENTRA_TRUST_EMAIL_FOR_LINKING,GOOGLE_TRUST_EMAIL_FOR_LINKING
+- [high/partia] Separate migrations connection and least-privilege role split (AUTH_DATABASE_URL_MIGRATIONS) — AUTH_DATABASE_URL_MIGRATIONS
+- [high/undocu] Automatic schema migrations on boot
+- [high/partia] Authentication mode selection (disabled / simple / full) and where the key actually lives — AUTHENTICATION_MODE,AUTH_ENABLED
+- [high/undocu] MFA lockout recovery (operator escape hatch)
+- [high/partia] WebAuthn: passkeys, biometrics and security keys — AUTH_WEBAUTHN_ENABLED
+- [high/partia] Email auth / magic links — AUTH_EMAIL_AUTH_ENABLED
+- [high/partia] Account lockout / brute-force protection — AUTH_LOCKOUT_ENABLED
+- [high/partia] ARGON2_SECRET (password pepper) — ARGON2_SECRET
+- [high/partia] AUTH_SECRET and rotation via AUTH_OLD_SECRET — AUTH_SECRET,AUTH_OLD_SECRET
+- [high/undocu] Connected Identities — user-managed SSO identity linking
+- [high/undocu] SSO_FORM_ACTION_ORIGINS — CSP form-action and Chromium-blocked SSO redirects — SSO_FORM_ACTION_ORIGINS,CSP_ENABLED
+- [high/partia] Provider route names and the mass re-link hazard — OIDC_ROUTE_NAME,ENTRA_ROUTE_NAME,GOOGLE_ROUTE_NAME,GITHUB_ROUTE_NAME
+- [high/partia] Per-domain (tenant) SSO for organizations — ORGS_SSO_ENABLED,SSO_ALLOW_PLATFORM_FALLBACK
+- [high/undocu] Account-creation and password-reset rate limiting — RESET_REQUEST_RATE_LIMIT_ENABLED,RESET_REQUEST_RATE_LIMIT_MAX_PER_IP,RESET_REQUEST_RATE_LIMIT_MAX_PER_EMAIL,RESET_REQUEST_RATE_LIMIT_WINDOW
+- [high/partia] Auth kill switches: AUTH_ENABLED / AUTH_SIGNUP / AUTH_SIGNIN / AUTH_REQUIRED — AUTH_ENABLED,AUTH_SIGNUP,AUTH_SIGNIN,AUTH_REQUIRED
+- [medi/undocu] WebAuthn autofill and passwordless signup (WEBAUTHN_AUTOFILL, WEBAUTHN_VERIFY_ACCOUNT) — WEBAUTHN_AUTOFILL,WEBAUTHN_VERIFY_ACCOUNT
+- [medi/partia] Password policy and argon2id hashing — AUTH_PASSWORD_REQUIREMENTS_ENABLED
+- [medi/partia] restrict_to — restricting the login page to a single method — AUTH_PASSWORD_ONLY,AUTH_EMAIL_AUTH_ONLY,AUTH_WEBAUTHN_ONLY,AUTH_SSO_ONLY
+- [medi/undocu] Remember me (persistent login) — AUTH_REMEMBER_ME_ENABLED
+- [medi/partia] Active sessions: view and revoke signed-in devices — AUTH_ACTIVE_SESSIONS_ENABLED
+- [medi/partia] Session cookie and lifetime configuration — SESSION_SECRET,SSL
+- [medi/partia] Email verification on signup (verify_account) and AUTH_AUTOVERIFY — AUTH_AUTOVERIFY,AUTH_VERIFY_ACCOUNT_ENABLED
+- [medi/undocu] First-time SSO sign-in for an existing account: password interstitial and mailbox-proof linking
+- [medi/partia] SAML is not supported natively
+- [medi/partia] Signup domain allowlist (ALLOWED_SIGNUP_DOMAIN) — ALLOWED_SIGNUP_DOMAIN
+- [medi/undocu] Password reset flow and its enumeration hardening
+- [medi/partia] Authentication audit logging
+- [medi/partia] Simple mode: what it actually supports
+- [low/partia] Per-provider SSO display names and the deprecated SSO_DISPLAY_NAME — SSO_DISPLAY_NAME,OIDC_DISPLAY_NAME,ENTRA_DISPLAY_NAME,GOOGLE_DISPLAY_NAME
+- [low/partia] TOTP authenticator issuer label (BRAND_TOTP_ISSUER) — BRAND_TOTP_ISSUER,BRAND_PRODUCT_NAME,SITE_NAME
+- [low/undocu] AUTH_SERVICE_URL (reserved / inert) — AUTH_SERVICE_URL
+- [low/undocu] Deprecated and inert auth variables (RODAUTH_HMAC_SECRET, GITHUB_KEY/SECRET, GOOGLE_KEY/SECRET) — RODAUTH_HMAC_SECRET,GITHUB_KEY,GITHUB_SECRET,GOOGLE_KEY
+
+### Email delivery, providers & deliverability
+- [crit/partia] Email delivery mode / transport selection (emailer.mode) — EMAILER_MODE
+- [crit/partia] Sender identity: From address and From name — FROM_EMAIL,FROM_NAME,FROM
+- [crit/undocu] SES sender-domain provisioning credentials — CUSTOM_MAIL_SES_REGION,CUSTOM_MAIL_SES_ACCESS_KEY_ID,CUSTOM_MAIL_SES_SECRET_ACCESS_KEY,AWS_ACCESS_KEY_ID
+- [crit/undocu] Email operations CLI (bin/ots email)
+- [high/partia] Plain SMTP delivery setup — SMTP_HOST,SMTP_PORT,SMTP_USERNAME,SMTP_PASSWORD
+- [high/undocu] AWS SES as the delivery transport — EMAILER_MODE,EMAILER_REGION,SMTP_USERNAME,SMTP_PASSWORD
+- [high/undocu] SendGrid as the delivery transport — EMAILER_MODE,SENDGRID_API_KEY,SMTP_PASSWORD
+- [high/undocu] Logger delivery mode (write emails to the log instead of sending) — EMAILER_MODE
+- [high/undocu] Disabled delivery mode for air-gapped and SSO-only installs — EMAILER_MODE
+- [high/undocu] SMTP unauthenticated-retry fallback
+- [high/partia] Truemail address validation (install-wide) — VERIFIER_EMAIL,VERIFIER_DOMAIN
+- [high/partia] Custom mail sender per organization/domain (feature enablement) — ORGS_CUSTOM_MAIL_ENABLED,ENABLE_ORGS
+- [high/undocu] Sender-domain provisioning provider selection (decoupled from transport) — CUSTOM_MAIL_PROVIDER
+- [high/partia] Lettermint sender-domain DNS settings and dual-token model — LETTERMINT_TEAM_TOKEN,CUSTOM_MAIL_LETTERMINT_SPF_CNAME_PREFIX,CUSTOM_MAIL_LETTERMINT_SPF_CNAME_TARGET
+- [high/undocu] Custom sender DNS records and dual verification flow
+- [high/undocu] Email suppression list (send-time recipient blocking)
+- [high/undocu] Bounce and complaint event ingestion and ESP feedback sync — AWS_REGION,CUSTOM_MAIL_SES_REGION,LETTERMINT_TEAM_TOKEN
+- [high/undocu] Expiration-warning emails
+- [high/partia] Asynchronous email delivery, worker tuning and sync fallback — JOBS_ENABLED,JOBS_FALLBACK_SYNC,EMAIL_WORKER_THREADS,EMAIL_WORKER_PREFETCH
+- [medi/partia] Lettermint as the delivery transport — EMAILER_MODE,LETTERMINT_API_TOKEN,LETTERMINT_BASE_URL
+- [medi/undocu] SMTP HELO domain — SMTP_DOMAIN
+- [medi/partia] Reply-To address — REPLYTO_EMAIL
+- [medi/undocu] Feedback form recipient routing — FEEDBACK_TO_EMAIL
+- [medi/partia] EMAILER_REGION and its misleading default — EMAILER_REGION,AWS_REGION
+- [medi/partia] Truemail SMTP-probe verifier identity — VERIFIER_EMAIL,VERIFIER_DOMAIN
+- [medi/undocu] Per-domain signup email validation (custom_signup_validation)
+- [medi/partia] SendGrid sender-domain DNS settings — CUSTOM_MAIL_SENDGRID_SUBDOMAIN
+- [medi/undocu] Colonel deliverability admin API
+- [medi/undocu] Secret-revealed notification (owner opt-in)
+- [medi/undocu] Transactional email template catalog
+- [low/undocu] Email logo display toggle — EMAILER_SHOW_LOGO
+- [low/partia] Local development mail capture (Mailpit) — SMTP_HOST,SMTP_PORT,SMTP_AUTH,SMTP_TLS
+
+### Background jobs, scheduler & maintenance operations
+- [crit/partia] Background job system master switch — JOBS_ENABLED
+- [crit/partia] RabbitMQ broker connection and credentials — RABBITMQ_URL,RABBITMQ_USER,RABBITMQ_PASS,RABBITMQ_VHOST
+- [crit/partia] Running background workers in production — SNEAKERS_PID_PATH,RABBITMQ_VHOST
+- [crit/partia] Running the scheduler daemon — SCHEDULER_PID_PATH
+- [high/undocu] RabbitMQ TLS (amqps) configuration — RABBITMQ_VERIFY_PEER,RABBITMQ_CA_CERTIFICATES
+- [high/partia] Queue and exchange provisioning (ots queue init) — RABBITMQ_MANAGEMENT_URL
+- [high/undocu] JOBS_SCHEDULER_ENABLED does not gate the scheduler — JOBS_SCHEDULER_ENABLED
+- [high/undocu] Fallback delivery when the broker is unavailable — JOBS_FALLBACK_SYNC
+- [high/undocu] Dead-letter queue inspection, replay and purge
+- [high/undocu] Dead-letter queue 7-day message TTL
+- [high/undocu] DLQ email consumer job (auth-email rescue)
+- [high/undocu] Queue reset and the immutable-queue-arguments hazard
+- [high/undocu] Plan cache refresh job
+- [high/undocu] Secret expiration warning emails
+- [high/undocu] Data maintenance jobs: master toggle and auto_repair safety model
+- [high/undocu] Index rebuild maintenance job
+- [high/undocu] Instances rebuild maintenance job
+- [high/undocu] Secret count reconciliation job
+- [high/undocu] Removal of the 32 JOBS_* tuning environment variables in v0.26 — JOBS_EXPIRATION_WARNINGS_ENABLED,JOBS_DLQ_CONSUMER_ENABLED,JOBS_DOMAIN_REFRESH_ENABLED,JOBS_MAINTENANCE_ENABLED
+- [medi/undocu] Per-worker concurrency and prefetch tuning — EMAIL_WORKER_THREADS,EMAIL_WORKER_PREFETCH,NOTIFICATION_WORKER_THREADS,NOTIFICATION_WORKER_PREFETCH
+- [medi/undocu] Publisher channel pool sizing — RABBITMQ_CHANNEL_POOL_SIZE
+- [medi/undocu] Queue topology reference
+- [medi/undocu] DLQ depth monitor job
+- [medi/partia] Job system status and queue depth reporting
+- [medi/undocu] Queue smoke test (ots queue ping)
+- [medi/undocu] Stripe catalog retry job
+- [medi/undocu] Custom-domain refresh job
+- [medi/undocu] Custom-domain favicon auto-fetch — FAVICON_FETCH_WORKER_THREADS,FAVICON_FETCH_WORKER_PREFETCH
+- [medi/undocu] Phantom cleanup maintenance job
+- [medi/undocu] Data consistency audit job
+- [medi/undocu] Participation GC maintenance job
+- [medi/undocu] Job system log channels — DEBUG_BUNNY
+- [low/partia] Worker liveness heartbeat logging — WORKER_HEARTBEAT_INTERVAL
+- [low/partia] Daemonize mode and PID files — SNEAKERS_PID_PATH,SCHEDULER_PID_PATH
+- [low/undocu] Scheduler heartbeat job
+- [low/undocu] Nightly favicon backfill scan
+- [low/undocu] Familia housekeeping chores job
+
+### Observability, diagnostics & logging
+- [crit/undocu] Sentry PII scrubbing and redaction guarantees
+- [crit/undocu] Request/error field allowlist (the one dial for log and Sentry field exposure) — LOG_HTTP_ALLOWED_ERROR_FIELDS
+- [crit/undocu] Deprecated-config boot policy (DEPRECATED_CONFIG_MODE) — DEPRECATED_CONFIG_MODE
+- [crit/undocu] Health endpoint network gating (HealthAccessControl / HEALTH_TRUSTED_CIDR) — HEALTH_TRUSTED_CIDR
+- [crit/undocu] Running without a global secret (ALLOW_NIL_GLOBAL_SECRET) — ALLOW_NIL_GLOBAL_SECRET
+- [high/partia] Diagnostics master switch (Sentry error tracking) — DIAGNOSTICS_ENABLED
+- [high/partia] Per-process Sentry DSN routing (backend / frontend / workers / shared fallback) — SENTRY_DSN,SENTRY_DSN_BACKEND,SENTRY_DSN_FRONTEND,SENTRY_DSN_WORKERS
+- [high/partia] Health and readiness endpoints (/health, /health/advanced, /auth/health)
+- [high/partia] Global log level and precedence (DEFAULT_LOG_LEVEL / LOG_LEVEL / ONETIME_DEBUG) — DEFAULT_LOG_LEVEL,LOG_LEVEL,ONETIME_DEBUG
+- [high/undocu] Named logger categories and per-category debug flags — DEBUG_LOGGERS,DEBUG_APP,DEBUG_AUTH,DEBUG_BILLING
+- [high/undocu] Log output format and destination (LOG_FORMATTER: color | json | default) — LOG_FORMATTER
+- [high/undocu] HTTP request capture modes (LOG_HTTP_CAPTURE: minimal | standard | debug) — LOG_HTTP_CAPTURE
+- [high/partia] logging.yaml as a first-class config file
+- [high/partia] `bin/ots status` — runtime service view
+- [high/undocu] `bin/ots diagnostics sentry` — doctor, check-dsn, send-test-event
+- [high/undocu] On-demand heap dumps (HEAP_DUMP_ENABLED / HEAP_DUMP_DIR) — HEAP_DUMP_ENABLED,HEAP_DUMP_DIR
+- [high/undocu] Secret verifier state as a health signal
+- [medi/partia] HTTP request logging toggle and level — LOG_HTTP_REQUESTS,LOG_HTTP_REQUESTS_LEVEL
+- [medi/undocu] Request log level escalation and slow-request threshold — LOG_HTTP_SLOW_REQUEST_MS
+- [medi/undocu] Error correlation id on error log lines (x-request-id / error_type)
+- [medi/undocu] Exception backtrace truncation (BACKTRACE_LEVEL / BACKTRACE_LINES) — BACKTRACE_LEVEL,BACKTRACE_LINES
+- [medi/undocu] Datastore and framework command logging (DEBUG_DATABASE, FAMILIA_DEBUG, OTTO_DEBUG, FAMILIA_SAMPLE_RATE) — DEBUG_DATABASE,FAMILIA_DEBUG,FAMILIA_SAMPLE_RATE,OTTO_DEBUG
+- [medi/partia] Sentry sampling, breadcrumbs and console error logging — SENTRY_SAMPLE_RATE,SENTRY_MAX_BREADCRUMBS,SENTRY_LOG_ERRORS
+- [medi/undocu] Sentry strict trace continuation (SENTRY_ORG_ID) — SENTRY_ORG_ID
+- [medi/undocu] Sentry release identity and source-map upload (SENTRY_RELEASE, SENTRY_DIST, SENTRY_AUTH_TOKEN, SENTRY_ORG, SENTRY_PROJECT, SENTRY_URL) — SENTRY_RELEASE,SENTRY_DIST,SENTRY_AUTH_TOKEN,SENTRY_ORG
+- [medi/partia] Frontend diagnostics: browser DSN exposure and Vue component tracking — SENTRY_DSN_FRONTEND,SENTRY_VUE_TRACK_COMPONENTS
+- [medi/partia] `bin/ots boot-test` — boot and initializer validation
+- [medi/undocu] Startup readiness 503 page (StartupReadiness middleware)
+- [medi/undocu] Role-aware container healthcheck script
+- [medi/partia] Development mode and the Vite frontend proxy boot guard — RACK_ENV,FRONTEND_HOST,ONETIME_ALLOW_DEV_FRONTEND
+- [medi/undocu] Domain context override for persona testing (DOMAIN_CONTEXT_ENABLED) — DOMAIN_CONTEXT_ENABLED,DOMAIN_CONTEXT
+- [medi/undocu] Development auth strategies (DEV_BASIC_AUTH / DEV_SESSION_AUTH) — DEV_BASIC_AUTH,DEV_SESSION_AUTH
+- [low/undocu] Request-log path ignore list
+- [low/undocu] Sentry event tagging (site_host, service, jurisdiction, environment)
+- [low/partia] Unbuffered stdout (STDOUT_SYNC) — STDOUT_SYNC
+
+### Custom domains, regions & incoming secrets
+- [crit/partia] Domain validation strategy: choosing between passthrough / approximated / caddy_on_demand — DOMAINS_VALIDATION_STRATEGY
+- [crit/undocu] passthrough strategy accepts any domain string with zero ownership proof — DOMAINS_VALIDATION_STRATEGY,DOMAINS_REQUIRE_VERIFIED
+- [crit/undocu] Require verified domain before secret creation (DOMAINS_REQUIRE_VERIFIED) — DOMAINS_REQUIRE_VERIFIED
+- [crit/undocu] caddy_on_demand currently refuses every certificate (ask endpoint returns 403 for all domains) — DOMAINS_VALIDATION_STRATEGY,ACME_ENDPOINT_ENABLED
+- [crit/undocu] The TXT ownership challenge record (_onetime-challenge-…)
+- [crit/undocu] INCOMING_ENABLED does not gate custom domains (canonical/custom split) — INCOMING_ENABLED,ORGS_INCOMING_SECRETS_ENABLED
+- [high/partia] Custom domains master switch (enable the feature at all) — DOMAINS_ENABLED
+- [high/partia] Canonical domain selection (DEFAULT_DOMAIN) — DEFAULT_DOMAIN,HOST
+- [high/partia] Internal ACME 'ask' endpoint — embedded vs standalone — ACME_ENDPOINT_ENABLED,ACME_LISTEN_ADDRESS,ACME_PORT
+- [high/undocu] Blocking the internal ACME endpoint at the reverse proxy — ACME_ENDPOINT_ENABLED
+- [high/partia] Approximated provider configuration (API key and vhost target) — APPROXIMATED_API_KEY,APPROXIMATED_VHOST_TARGET
+- [high/partia] Cluster proxy settings drive the DNS instructions shown to your customers — APPROXIMATED_PROXY_IP,APPROXIMATED_PROXY_HOST,APPROXIMATED_PROXY_NAME
+- [high/undocu] Unknown validation_strategy silently downgrades to passthrough (features.domains.strict_strategy)
+- [high/partia] Reverse-proxy requirements for serving tenant hostnames
+- [high/partia] Homepage secrets mode: private landing page / create form / incoming form
+- [high/partia] Multi-region deployment: REGIONS_ENABLED, JURISDICTION, JURISDICTIONS — REGIONS_ENABLED,JURISDICTION,JURISDICTIONS
+- [high/undocu] JURISDICTION also filters the Stripe billing catalog — JURISDICTION
+- [high/partia] Incoming secrets on the canonical domain (/incoming) — operator setup — INCOMING_ENABLED,INCOMING_RECIPIENT_1,INCOMING_RECIPIENT_2,INCOMING_RECIPIENT_3
+- [high/undocu] Incoming submission rate limiting (INCOMING_RATE_LIMIT_*) — INCOMING_RATE_LIMIT_ENABLED,INCOMING_RATE_LIMIT_MAX_PER_IP,INCOMING_RATE_LIMIT_MAX_PER_RECIPIENT,INCOMING_RATE_LIMIT_WINDOW
+- [high/partia] Global default passphrase for incoming secrets (INCOMING_DEFAULT_PASSPHRASE) — INCOMING_DEFAULT_PASSPHRASE
+- [high/partia] Per-domain incoming recipients (customer-facing setup)
+- [medi/undocu] Shipped Caddyfile example is stale and points the ask directive at the wrong URL
+- [medi/undocu] ACME README documents a check_verification=false query parameter that no longer exists
+- [medi/partia] Domain verification state machine (unverified → pending → resolving → verified)
+- [medi/undocu] Domain refresh background job (jobs.domain_refresh)
+- [medi/undocu] Domain context override for local testing (DOMAIN_CONTEXT_ENABLED) — DOMAIN_CONTEXT_ENABLED,DOMAIN_CONTEXT
+- [medi/partia] Who may create a secret on a custom domain (domain permission matrix)
+- [medi/partia] Cross-region subscription federation (FEDERATION_SECRET) — FEDERATION_SECRET
+- [medi/undocu] Deprecated regions/domains config paths (site.regions, site.domains, array-form jurisdictions)
+- [medi/partia] Incoming memo length and TTL — and why custom domains ignore your setting — INCOMING_MEMO_MAX_LENGTH,INCOMING_DEFAULT_TTL
+- [medi/partia] Enabling per-domain incoming for organizations (ORGS_INCOMING_SECRETS_ENABLED) — ORGS_INCOMING_SECRETS_ENABLED
+- [low/undocu] Approximated DNS widget (auto-detect the customer's DNS provider)
+- [low/undocu] Incoming secrets delivered on the custom domain (links and sender identity)
+
+### Branding, interface customization & internationalization
+- [crit/undocu] Brand packs for self-hosted white-labelling (BRAND_PACK / BRAND_ASSETS_DIR) — BRAND_PACK,BRAND_ASSETS_DIR
+- [crit/partia] Deprecated header.branding config published as current (SITE_NAME / LOGO_URL / LOGO_ALT) — SITE_NAME,LOGO_URL,LOGO_ALT
+- [crit/undocu] default_locale not in locales list silently disables all internationalization — I18N_DEFAULT_LOCALE
+- [high/undocu] Install-wide brand identity block (brand:) and its precedence chain — BRAND_PRODUCT_NAME,BRAND_PRODUCT_DOMAIN,BRAND_SUPPORT_EMAIL
+- [high/undocu] Masthead and email logo (BRAND_LOGO_URL / BRAND_LOGO_DARK_URL / BRAND_LOGO_ALT) — BRAND_LOGO_URL,BRAND_LOGO_DARK_URL,BRAND_LOGO_ALT
+- [high/undocu] Favicon, mobile and social icon overrides (BRAND_FAVICON_URL / BRAND_APPLE_TOUCH_ICON_URL / BRAND_OG_IMAGE_URL) — BRAND_FAVICON_URL,BRAND_APPLE_TOUCH_ICON_URL,BRAND_OG_IMAGE_URL
+- [high/undocu] Brand-pack resolution diagnostics CLI (bin/ots config brand) — BRAND_PACK,BRAND_ASSETS_DIR
+- [high/partia] Homepage mode: internal vs external (UI_HOMEPAGE_MODE + CIDR / header detection) — UI_HOMEPAGE_MODE,UI_HOMEPAGE_MATCHING_CIDRS,UI_HOMEPAGE_MODE_HEADER
+- [high/partia] Client IP resolution for homepage CIDR matching (trusted_proxy) — stale removed vars in docs — UI_HOMEPAGE_TRUSTED_PROXY_DEPTH,UI_HOMEPAGE_TRUSTED_IP_HEADER,UI_HOMEPAGE_DEFAULT_MODE,TRUSTED_PROXY_HEADER
+- [high/partia] Internationalization master switch (I18N_ENABLED) — I18N_ENABLED
+- [high/partia] Restricting or extending the supported locale list
+- [medi/undocu] MFA / TOTP authenticator issuer label (BRAND_TOTP_ISSUER) — BRAND_TOTP_ISSUER,BRAND_PRODUCT_NAME
+- [medi/undocu] Transactional email branding (signature name, support email, logo, brand colour) — BRAND_SIGNATURE_NAME,BRAND_SUPPORT_EMAIL,BRAND_PRIMARY_COLOR
+- [medi/undocu] Brand colour and visual tokens (primary colour, corner style, font family, button text contrast) — BRAND_PRIMARY_COLOR,BRAND_CORNER_STYLE,BRAND_FONT_FAMILY,BRAND_BUTTON_TEXT_LIGHT
+- [medi/undocu] brand.yaml pack identity manifest — BRAND_PACK,BRAND_ASSETS_DIR
+- [medi/undocu] Brand pack generator and build-time baking (pnpm gen:favicons, --build-arg BRAND_PACK) — BRAND_PACK,MARK_OUT_PUBLIC_DIR
+- [medi/undocu] Disabled-homepage landing variants (closed / minimal / v1) and the ?variant= override — DEFAULT_DISABLED_HOMEPAGE_VARIANT,DEFAULT_CUSTOM_DOMAIN_DISABLED_HOMEPAGE_VARIANT
+- [medi/undocu] Recipient orientation link on gated homepages (HOMEPAGE_PUBLIC_LINKS_RECIPIENT_INTRO) — HOMEPAGE_PUBLIC_LINKS_RECIPIENT_INTRO
+- [medi/partia] Date and time display formats (I18N_DATE_FORMAT / I18N_DATETIME_FORMAT) — I18N_DATE_FORMAT,I18N_DATETIME_FORMAT
+- [medi/partia] Locale fallback chains and browser-language detection
+- [medi/undocu] End-user language switching in the application
+- [medi/undocu] Per-domain recipient instructions and description (custom-domain brand settings)
+- [medi/partia] Per-domain Brand Manager editor: token vocabulary and three-path UI
+- [medi/partia] Per-domain branding precedence over installation branding — BRAND_LOGO_URL,BRAND_PRIMARY_COLOR
+- [medi/partia] Secret-form capability flags (UI_CAPABILITIES_*) — UI_CAPABILITIES_BURN,UI_CAPABILITIES_SHOW,UI_CAPABILITIES_RECEIPT,UI_CAPABILITIES_RECIPIENT
+- [medi/partia] Masthead layout controls (HEADER_ENABLED, HEADER_NAV_ENABLED, LOGO_LINK, LOGO_SHOW_NAME, LOGO_PROMINENT) — HEADER_ENABLED,HEADER_NAV_ENABLED,LOGO_LINK,LOGO_SHOW_NAME
+- [medi/partia] Public footer links and vendor-URL defaults (FOOTER_LINKS + TERMS/PRIVACY/DOCS/STATUS/ABOUT/CONTACT) — FOOTER_LINKS,TERMS_URL,PRIVACY_URL,DOCS_URL
+- [medi/partia] Workspace footer links for authenticated users (WORKSPACE_LINKS and friends) — WORKSPACE_LINKS,WORKSPACE_API_DOCS_URL,WORKSPACE_BRANDING_GUIDE_URL,WORKSPACE_FEEDBACK_URL
+- [low/undocu] Per-domain default locale (domain brand locale)
+- [low/undocu] Version disclosure in the footer (FOOTER_VERSION_ENABLED) — FOOTER_VERSION_ENABLED
+- [low/undocu] Help modal on secret pages (HELP_ENABLED) — HELP_ENABLED
+- [low/partia] Web UI master switch (UI_ENABLED) — UI_ENABLED
+- [low/undocu] PWA web manifest branding (/site.webmanifest) — BRAND_PRODUCT_NAME,BRAND_PRIMARY_COLOR
+- [low/undocu] BRAND_PRODUCT_DOMAIN (stored, currently inert) — BRAND_PRODUCT_DOMAIN
+
+### Organizations, teams, entitlements, billing & admin (colonel)
+- [crit/undocu] The entitlement model (what entitlements are, and the 23-string catalog)
+- [crit/undocu] Plan ∩ role intersection: why a paid feature can still be refused
+- [crit/undocu] Self-hosted standalone mode grants every entitlement (fail-open) — BILLING_ENABLED
+- [crit/undocu] Fail-closed plan resolution: PlanCacheMissError breaks an org — BILLING_ENABLED,STRIPE_API_KEY
+- [crit/partia] billing.yaml: the self-hosted billing/plan catalog file — BILLING_ENABLED,BILLING_CURRENCY,CURRENCY,STRIPE_API_KEY
+- [crit/partia] Colonel role and how to grant admin access
+- [crit/partia] The Colonel admin console and its 14 sections
+- [crit/undocu] Colonel network isolation (ADMIN_ALLOWED_CIDRS) and its trusted-proxy dependency — ADMIN_ALLOWED_CIDRS,TRUSTED_PROXY_ENABLED
+- [crit/partia] Secret Activity: the shipped organization audit trail
+- [high/undocu] Organizations as the tenancy and billing unit — ENABLE_ORGS
+- [high/partia] Organizations UI toggle and the org context switcher (ENABLE_ORGS) — ENABLE_ORGS
+- [high/undocu] Organization settings surface (general / members / domains / subscription / SSO / activity)
+- [high/partia] Organization roles: owner, admin, member
+- [high/partia] Member invitations lifecycle (invite, resend, revoke, accept, decline, sign-up-and-accept)
+- [high/undocu] Organization ownership transfer
+- [high/undocu] Organization and membership integrity tooling (doctor / reconcile)
+- [high/undocu] Operator entitlement overrides (org-level and membership-level)
+- [high/partia] Per-install org feature kill switches (ORGS_SSO_ENABLED, ORGS_CUSTOM_MAIL_ENABLED, ORGS_INCOMING_SECRETS_ENABLED) — ORGS_SSO_ENABLED,ORGS_CUSTOM_MAIL_ENABLED,ORGS_INCOMING_SECRETS_ENABLED,INCOMING_ENABLED
+- [high/undocu] Plan catalog authoring and the push/pull/validate/drift workflow
+- [high/undocu] Plan definition schema: tiers, tenancy, entitlements, limits, prices, display
+- [high/partia] Stripe integration configuration (keys, webhooks, checkout host, automatic tax, currency) — STRIPE_API_KEY,PUBLIC_STRIPE_API_KEY,STRIPE_WEBHOOK_SIGNING_SECRET,STRIPE_CHECKOUT_HOST
+- [high/undocu] Subscription self-service surfaces (plans page, checkout, portal, change/cancel/reactivate, invoices, currency migration)
+- [high/undocu] Audit terminology: Secret Activity vs Security Events vs operator audit log
+- [medi/undocu] Domain-scoped memberships (SSO just-in-time members)
+- [medi/undocu] Free-tier fallback entitlements and the two conflicting limit sources — TTL_MAX_ANONYMOUS,PLAN_TTL_ANONYMOUS
+- [medi/partia] Regional catalog isolation (JURISDICTION / region matching) — JURISDICTION,JURISDICTIONS
+- [medi/undocu] Payer decoupling: billing account vs organization
+- [medi/undocu] Billing background jobs: plan cache refresh, catalog retry, billing worker — BILLING_WORKER_THREADS,BILLING_WORKER_PREFETCH,JOBS_SCHEDULER_ENABLED
+- [medi/undocu] System role hierarchy: colonel, admin, staff, customer
+- [medi/undocu] Colonel audit trail (ColonelAuditEvent)
+- [medi/partia] Plan tier → entitlement mapping shown to buyers
+- [medi/undocu] Control plane vs data plane: admin surfaces are canonical-domain only (planned) — CANONICAL_DOMAIN,DEFAULT_DOMAIN
+- [low/undocu] Colonel plan-preview mode (request-scoped entitlement preview)
+- [low/undocu] Complimentary and pro-bono plans
+- [low/undocu] Per-customer early-access feature flags

--- a/docs/planning/documentation-audit-2026-08.md
+++ b/docs/planning/documentation-audit-2026-08.md
@@ -1,0 +1,439 @@
+# Documentation audit — August 2026
+
+**Question asked:** we have shipped many features with no documentation. Which topics are missing, and
+how should the docs site be restructured to hold them?
+
+**Scope:** the product's full configuration surface (`.env.reference`, `etc/defaults/config.defaults.yaml`,
+`etc/defaults/auth.defaults.yaml`, `etc/defaults/logging.defaults.yaml`, `etc/examples/`, 194 internal
+specs/ADRs/runbooks, `CHANGELOG.rst`, and implementation code where a config comment was ambiguous)
+compared against the 61 published English pages and the sidebar in `config/sidebar.mjs`.
+
+**Method:** nine parallel domain surveys, one docs-IA baseline pass (including a study of Kinde, Linear,
+Sentry, Stripe, Supabase, Tailscale and Vault), three competing IA proposals, a synthesis, then an
+adversarial verifier tasked with *refuting* every claimed gap and a completeness critic tasked with
+finding what the surveys missed. Both adversarial passes landed hits; their corrections are applied
+below and recorded in Appendix A rather than quietly dropped.
+
+---
+
+## Headline numbers
+
+| | |
+|---|---|
+| Features / behaviours catalogued | **305** |
+| Undocumented (absent from `en/` entirely) | **183** |
+| Partial (mentioned but not usable from the docs alone) | **121** |
+| Published statements that are **factually wrong** | **~25** |
+| Env vars in `.env.reference` | **353** |
+| Env vars documented on the site | **149**, of which **19** are no longer supported |
+| Published English pages | 61, of which **8 are orphaned** (not in the sidebar) |
+| Top-level sidebar entries | 14 |
+
+Three findings, in descending order of harm.
+
+---
+
+## Finding 1 — the docs publish statements that are wrong
+
+This outranks the coverage gap. A reader who finds nothing goes looking; a reader who finds a wrong
+command follows it. Each of these was verified against source this session:
+
+| Published claim | Reality | Consequence |
+|---|---|---|
+| `TTL_OPTIONS` is comma-separated (`environment-variables.md:447`) | parser is `ttl_options.split(/\s+/)` (`lib/onetime/config.rb:470`) | operator's whole expiration menu silently collapses to a single 5-minute option |
+| `CSP_ENABLED (default: false)` (`configuration.md:275`) | shipped default is `!= 'false'`, i.e. **true** (`config.defaults.yaml:447`) | operators disable CSP believing they are enabling it |
+| `SENTRY_SAMPLE_RATE=1.0`, `SENTRY_MAX_BREADCRUMBS=50` | shipped `0.10` and `5` (`config.defaults.yaml:1261`) | 10× Sentry bill for anyone copying the block |
+| `rake ots:init`, `./install.sh init\|doctor` | do not exist — real commands are `rake ots:secrets`, `bin/setup --init\|--doctor` | `install.sh` is invoked four times across the docs and is not in the repo |
+| `bin/ots doctor`, `bin/ots customer create\|promote` | not registered commands | dead-end for a new operator |
+| `:colonels:` auto-promotion (`getting-started.md:93`) | removed from the product | new self-hoster ends up with **no admin account** |
+| "no manual step needed" for password migration (`upgrading-v0-24.md:244`) | `bin/ots customers sync-auth-accounts --run` is required | **every pre-existing user locked out** after upgrade |
+| nginx snippet uses `$proxy_add_x_forwarded_for` (`installation.md:244,253`) | appends rather than overwrites | resolved client IPs become spoofable |
+| three removed `UI_HOMEPAGE_*` vars still published as settable | removed | under the default `DEPRECATED_CONFIG_MODE=strict` a removed key **refuses boot** |
+| `team/audit-log.md` says "Status: Planned" | shipped in 0.26.0 and since renamed | advertises an unshipped feature that shipped |
+
+Underneath: `configuration.md` is 636 lines of which **596 are one unbroken YAML fence** with no
+headings or anchors, and it is already missing five whole upstream stanzas (`brand:`, `jobs:`,
+`diagnostics:`, `development:`, `compatibility:`). `environment-variables.md` stacks a v0.25 dump on a
+contradictory v0.24 section. Both are hand-copied forks of files that keep changing. **You cannot fix
+copy-drift with better writing, only by deleting the copy** — which is why the plan below ends in a
+generated reference.
+
+Two live navigation defects found while mapping: `sidebar.mjs:217` links a path with no backing
+content-collection file, and `sidebar.mjs:255` links `translations/universal`, whose only file is
+`_index.md` — which Astro content collections skip.
+
+---
+
+## Finding 2 — 183 features have no page at all
+
+Zero-hit greps across the entire `en/` tree: `TXT` · `passkey` · `DLQ` · `sqlite` · `password reset` ·
+`suppress` · `catalog` · `429` · `Retry-After` · `TRUSTED_PROXY` · `HEALTH_TRUSTED_CIDR` ·
+`STANDALONE_ENTITLEMENTS`. `BRAND` returns two hits, both a URL constant — so the entire
+17-variable branding subsystem plus brand packs is absent.
+
+The `TXT` result is the most expensive single gap on the site: the product UI presents the
+`_onetime-challenge-*` TXT ownership record **first**, verification cannot complete without it, and
+`custom-domains/setup-guide.md` never mentions it. Every customer following that page exactly sits at
+*Pending* forever.
+
+Gap density by domain:
+
+| Domain | Features | Undocumented | Partial | Critical |
+|---|---|---|---|---|
+| Organizations, teams, entitlements, billing & admin | 35 | 24 | 11 | 9 |
+| Background jobs, scheduler & maintenance | 37 | 29 | 8 | 4 |
+| Observability, diagnostics & logging | 35 | 23 | 12 | 5 |
+| HTTP security, sessions, middleware & network | 29 | 21 | 8 | 5 |
+| Branding, interface & internationalization | 34 | 20 | 14 | 3 |
+| Email delivery, providers & deliverability | 32 | 19 | 13 | 4 |
+| Secrets, cryptography & key management | 32 | 17 | 14 | 6 |
+| Custom domains, regions & incoming secrets | 33 | 16 | 17 | 6 |
+| Authentication & identity | 38 | 14 | 24 | 6 |
+
+The full topic-by-topic inventory is in
+[`documentation-audit-2026-08-topics.md`](./documentation-audit-2026-08-topics.md).
+
+There is also **no task layer**. Across 61 pages there are five genuine how-tos and four of those are
+for operators. No page walks an end user through creating a secret, choosing a TTL, setting a
+passphrase, using the receipt, or burning a link — the product's core action.
+`introduction/index.md` is titled "Getting Started" and contains zero steps.
+
+---
+
+## Finding 3 — the navigation encodes the price list, not the product
+
+`sidebar.mjs:122-142` files pages under the billing tier that unlocks them. Consequences:
+
+- Eleven pages that all live at `/custom-domains/` URLs are scattered across **four** nav groups. The
+  file's own comment concedes the URL and the nav path disagree.
+- Two of the four "Team Plus" pages advertise features from permanent top-level navigation.
+- The taxonomy needed a fudge on its first collision: `audit_logs` belongs to no plan and was parked
+  under Team Plus by fiat.
+- Repricing rewrites navigation and invalidates every deep link.
+
+Meanwhile seven top-level slots go to Regions, six of which are one 43–47 line template; the whole REST
+API is a 30-line redirect notice carrying the same nav weight as all of Self-Hosting; and 378 lines of
+SDK examples sit in a one-item group called "Resources".
+
+**Recommendation: billing tier becomes metadata, never navigation** — a `plan:` frontmatter field
+rendered as an inline sidebar badge (the badge mechanism already exists and is used for ★ on
+`brand-guide` and `sso`), plus one *Plans & billing* section for the commercial mechanics.
+
+---
+
+## Recommended information architecture
+
+**14 top-level entries → 8.** Read as a sequence: evaluate → use → operate → integrate → verify.
+
+```
+Home
+Start here
+Using Onetime Secret ─ Sharing secrets · Your account · Organizations & members
+                       Custom domains · Plans & billing
+Self-hosting ────────── Install & deploy · Configure · Features · Operate
+                       Troubleshoot & upgrade
+API & SDKs
+Reference
+Trust & security
+Translations & contributing
+```
+
+Five rules govern everything below.
+
+1. **The audience fork is made once, early, and named.** *Start here* ends with a decision page;
+   thereafter *Using Onetime Secret* is the hosted surface and *Self-hosting* is the operator surface.
+   These are not variants of one tree. For "add a custom domain", the hosted admin reads a five-step
+   DNS wizard; the operator chooses among three validation strategies, one of which (`passthrough`,
+   the default) performs no ownership check at all. Disjoint procedures, disjoint prerequisites,
+   disjoint failure modes.
+2. **Shared mechanism is stated once and linked to.** Nine hosted↔operator feature pairs (custom
+   domains, SSO, incoming secrets, email sender, sign-in/sign-up config, branding, homepage modes,
+   secret options, regions) carry reciprocal `:::note` asides in both directions — assertable in
+   `bin/check-links.sh` alongside the existing lychee run.
+3. **Reference owns every default and every value.** Prose pages state consequences and link to the
+   generated row; they never restate a number. Without this rule the mirrored pages drift straight
+   back to the state this plan exists to fix.
+4. **Billing tier is metadata, never navigation.**
+5. **Titles lead with the reader's words, not internal vocabulary.** "Receipt" and "Secret Activity"
+   are terms the product renamed *to*; the page titles seed the synonyms a reader would actually
+   search ("private link", "burn a secret", "did they open my link", "audit log").
+
+### The tree
+
+Legend — `NEW` · `UPD` update in place · `MOV` moved · `MRG` merged in · `SPL` split out.
+
+#### 1. Home · 1 page
+`UPD` `en/index.mdoc` — route by intent (evaluate / use / integrate / operate) instead of restating the
+marketing site. Its current paid CTA points at `pricing/index.md`, which is an orphan.
+
+#### 2. Start here · 5 pages
+| | Page | Covers |
+|---|---|---|
+|`MRG`|`start/index`|absorbs `docs-overview` + `introduction/index` + `introduction/guides`|
+|`NEW`|`start/send-your-first-secret`|the product's core action, end to end|
+|`MRG`|`start/run-your-own-instance`|absorbs `self-hosting/getting-started`|
+|`MOV`|`start/hosted-or-self-hosted`|from `self-hosting/self-hosting-vs-hosted`|
+|`NEW`|`start/glossary`|receipt vs private link vs metadata; passphrase vs password; organization vs workspace vs team; colonel vs admin vs staff; entitlement vs permission vs capability; Secret Activity vs Security Events; canonical vs custom domain|
+
+The glossary is the cheapest fix in the plan. A dozen contested terms are currently disambiguated only
+inside long pages, reachable only by already knowing which page hides them.
+
+#### 3. Using Onetime Secret · 30 pages
+
+**Sharing secrets** (7) — `UPD share/index` (rewritten as a procedure) · `NEW share/your-receipt`
+(private link, burn, one-time reveal of a generated password, `GENERATED_VALUE_DISPLAY_TTL`) ·
+`NEW share/what-recipients-see` · `NEW share/when-a-link-doesnt-work` (the unified "no longer
+available" response and the deliberate absence of an existence oracle — highest-volume support
+deflection page on the site) · `SPL share/receiving-secrets` · `MOV share/use-cases` ·
+`MOV share/why-secret-links`
+
+**Your account** (8) — `NEW account/signing-in` (incl. password reset, absent today) ·
+`NEW account/two-factor-and-passkeys` (TOTP, recovery codes, WebAuthn — `passkey` has zero hits) ·
+`NEW account/sessions-and-identities` · `NEW account/dashboard-and-recent-secrets` ·
+`NEW account/change-your-email` · `NEW account/close-your-account` · `NEW account/preferences` ·
+`MOV account/change-your-region`
+
+> Email change and account deletion are both shipped, both irreversible, and both absent. "How do I
+> delete my account and my data" is the question a privacy-first product is most expected to answer,
+> and the site currently cannot.
+
+**Organizations & members** (6) — `MRG organizations/index` (absorbs `team/shared-dashboard`) ·
+`NEW organizations/roles-and-permissions` (**the plan ∩ role rule** — why a paid feature is still
+refused) · `MOV organizations/inviting-members` · `NEW organizations/ownership-and-transfer` ·
+`MOV organizations/sso` · `UPD organizations/audit-trail` (the shipped Secret Activity feature, titled
+for what people search)
+
+**Custom domains** (7) — the four tier groups collapse into one. `MRG custom-domains/index` (absorbs
+`how-it-works` + `use-cases`) · `UPD custom-domains/setup-guide` (**must gain the missing TXT
+ownership step**) · `UPD custom-domains/dns-validation` · `MOV custom-domains/branding` ·
+`UPD custom-domains/email-sender` · `MRG custom-domains/homepage-and-incoming` ·
+`MRG custom-domains/access-and-privacy`
+
+**Plans & billing** (2) — `MRG billing/index` (de-orphans `pricing/index`, absorbs `compare-plans`) ·
+`NEW billing/managing-your-subscription`
+
+#### 4. Self-hosting · 43 pages
+
+**Install & deploy** (8) — `UPD self-hosting/index` · `UPD self-hosting/simple-or-full-auth` ·
+`NEW install/images-and-variants` (registry, tag policy, `OTS_IMAGE_TAG`, and the **lite / caddy / s6**
+variants — none named anywhere today, though two of them are the intended companions to the next two
+pages) · `SPL install/docker` · `SPL install/linux` · `SPL install/run-as-a-service` ·
+`SPL install/reverse-proxy-and-tls` · `NEW install/verify`
+
+**Configure** (8) — `UPD configure/index` (file inventory + precedence + `DEPRECATED_CONFIG_MODE`) ·
+`NEW configure/secrets-and-keys` · `NEW configure/authentication` · `NEW configure/sso` ·
+`NEW configure/email` · `NEW configure/secret-options` · `NEW configure/sessions-and-cookies` ·
+`NEW configure/security-headers`
+
+**Features** (10) — `NEW features/custom-domains` · `NEW features/caddy-on-demand-tls` ·
+`NEW features/incoming-secrets` · `NEW features/branding` (brand packs, `BRAND_ASSETS_DIR`, all 17
+`BRAND_*` vars) · `NEW features/interface-and-homepage` · `NEW features/languages` ·
+`NEW features/multi-region` · `NEW features/billing-and-entitlements` · plus two **operator-only**
+surfaces with no hosted counterpart, which fell out of the first draft precisely because it was
+organised as an audience mirror: `NEW features/feedback-channel` · `NEW features/broadcast-banner`
+
+**Operate** (10) — `NEW operate/background-jobs` · `NEW operate/queues-and-dlq` ·
+`NEW operate/scheduled-and-maintenance-jobs` · `NEW operate/datastore` (Valkey/Redis is the **system of
+record, not a cache** — persistence, `appendonly`, backup semantics) ·
+`NEW operate/scale-and-tune` (the entire `SERVER & WORKER TUNING` banner section — `PUMA_WORKERS`,
+`PUMA_MIN/MAX_THREADS`, `FAMILIA_POOL_SIZE/TIMEOUT`, `RABBITMQ_CHANNEL_POOL_SIZE`) ·
+`NEW operate/health-and-monitoring` · `NEW operate/logging-and-error-tracking` ·
+`NEW operate/backup-and-key-rotation` · `NEW operate/rate-limits-and-network-access` ·
+`NEW operate/admin-console` (the Colonel and its 14 sections) ·
+`SPL operate/harden-your-deployment` (moved **into** the operator tree — a pre-production checklist
+belongs one hop from where the operator is working, not in the compliance section)
+
+**Troubleshoot & upgrade** (7) — `NEW troubleshoot/boot-failures` ·
+`NEW troubleshoot/sign-in-and-signup-problems` · `NEW upgrades/data-migrations` (`bin/ots migrate` is a
+stateful runner with dry-run, status, rollback and a `CONFIG_MIGRATE=check|auto|skip` boot gate; today
+it would get one row in a CLI table) · `NEW upgrades/index` · `NEW upgrades/v0-26` (**must include the
+CHANGELOG's bolded Action Required migration**, `bin/ots migrate --run 20260703_01_disable_homepage_auth_links`) ·
+`UPD upgrades/v0-24` · `MOV upgrades/v0-23`
+
+#### 5. API & SDKs · 5 pages — promoted to top level
+`UPD api/index` (base URLs, versions) · `NEW api/authentication` · `NEW api/errors-and-rate-limits`
+(429 and `Retry-After`, both zero-hit today) · `NEW api/versions` · `MOV api/client-libraries`
+
+> This is the most-linked developer material on any docs site. Burying it under a reference spine
+> nobody browses inherits the wrong navigation behaviour.
+
+#### 6. Reference · 13 pages — generated, English-only
+`NEW reference/index` (how to read it; **which page owns a default**) ·
+`SPL reference/environment-variables` · `NEW reference/deprecated-and-removed` (what makes
+`DEPRECATED_CONFIG_MODE=strict` survivable) · `NEW reference/cli` (`bin/ots`) ·
+`NEW reference/scheduled-jobs` · `NEW reference/health-endpoints` · then *Configuration keys* (7),
+**titled by subject rather than by YAML stanza**: `configuration-files-and-precedence` ·
+`generator` (moved, given a content wrapper so it stops being an invisible sidebar entry) ·
+`site-and-interface` · `features-and-branding` · `datastore-and-queues` · `email-and-delivery` ·
+`auth-logging-and-billing-files`
+
+#### 7. Trust & security · 8 pages
+`UPD security/index` · `NEW security/how-one-time-access-works` · `NEW security/passphrase-protection` ·
+`UPD security/data-protection` · `MRG security/where-your-data-lives` (the five region pages) ·
+`MOV security/best-practices` · `MRG security/our-principles` (the four principles pages) ·
+`security/vulnerability-disclosure`
+
+#### 8. Translations & contributing · 10 pages
+Renamed from "Contribute", which today holds nine pages of translation guidance and no contributor
+documentation at all. `NEW contribute/developer-on-ramp` (`bin/dev`, `bin/setup --test`, the
+containerized test lanes, the 32 ADRs) plus the nine existing translation pages moved, including the
+five currently orphaned under `translations/universal/`.
+
+**Totals: 61 pages → 115. ~63 new, ~20 moved, ~14 merged away, 1 deleted.**
+
+---
+
+## Sequencing
+
+**Phase 1 — stop the bleeding (1–2 weeks).** Corrections in place. No sidebar change, no new
+translation keys, no redirects, so it ships independently of every other decision here. Fix the ~25
+wrong statements in Finding 1; add the missing TXT step to `setup-guide.md`; publish
+`configure/secrets-and-keys` and `share/when-a-link-doesnt-work` early; rename
+`translations/universal/_index.md` → `index.md` to fix the live 404; delete
+`translations/language-notes.md` (an 11-line unfinished `[placeholder]` table).
+*Start the app-repo reference generator now* — it is the critical path for Phase 4.
+
+**Phase 2 — reshape and build the end-user task layer (5–7 weeks).** 14 top-level entries become 8;
+tiers leave navigation; orphans are absorbed; the end-user surface gets its first real how-tos.
+Prerequisite: extend `docsSchema()` with `plan`, `audience`, `pageType`, `translate`, `sourceOfTruth`.
+
+**Phase 3 — the operator install and configure tree (6–8 weeks).** Split `installation.md` (470 lines,
+six unrelated jobs) into task pages; write the operator feature pages. Highest per-page research cost
+— most require reading implementation to state a default correctly.
+
+**Phase 4 — the generated reference and the Day-2 layer (7–9 weeks, ~3 engineering).** Stand up the
+pipeline, retire `configuration.md` and `environment-variables.md`, complete Operate and Troubleshoot.
+Ship `reference/environment-variables` and `reference/deprecated-and-removed` first — highest defect
+density, simplest generators, straight replacements.
+
+**Phase 5 — drift prevention (3–4 weeks).** Every defect in this audit went unnoticed because nothing
+checks for it. Add `check:orphans`, `check:nav`, a frontmatter linter, and a reference-drift CI gate.
+Today's only QA scripts are link checkers and a vitest suite covering the config generator alone.
+
+---
+
+## Implementation mechanics
+
+**`config/sidebar.mjs`** — delete the four tier factories and the 20-line comment block encoding the
+filing rule. No helper changes needed for nesting: `createGroup` passes `items` straight through and
+Starlight accepts groups as group children. While in the file, fix `createLink("overview", …)` being
+used **seven times** (the sidebar renders "Overview" seven times with only group context to
+disambiguate), and the two broken links noted in Finding 1.
+
+**`src/content/i18n/en.json`** — ~85 new keys. **All can ship English-only**: `buildTranslations()`
+includes a locale only if that bundle already has the key, and omitted locales fall back to the English
+label. The file's own comment says this is deliberate. Ten of the 13 dead keys (`coreConfig`,
+`systemSettings`, `createSecrets`, …) can be removed; three are reclaimed by the new API group.
+
+**`config/redirects.mjs`** — ~30 families × 26 locale prefixes. Both required patterns already have
+precedent (per-locale fan-out for the `principles/trust` merge; many-to-one collapse for the
+`/rest-api/v1|v2/*` tree). Generate from a `movedPages` array, don't hand-write. Note the existing
+top-level `"/pricing"` entry sends the bare path off-site while `/en/pricing/` is an unnavigable
+orphan, and `"/getting-started": "/en/introduction"` will chain into a page that no longer exists.
+
+**Translation.** Measured: no locale is at parity (best 41/61; most 36–40), and ten further directories
+hold 3 files each with no i18n bundle and no sidebar entry. Proposed policy — translate the 40
+end-user pages (Home, Start here, Using Onetime Secret, Trust & security); make Self-hosting, Reference
+and Translations English-only by construction, which is already the de facto state.
+**40 × 16 = 640 obligations against today's 976 — a 34% reduction in standing liability while English
+coverage nearly doubles.** Mechanism: a `translate: z.boolean().default(true)` frontmatter field plus a
+check in `bin/translation-pluribus-util`. Do **not** copy the `configuration-generator.astro` escape
+hatch — it is English-only but also drops out of Pagefind, prev/next and the content collection, which
+is exactly why that sidebar entry currently points at something invisible.
+
+**The generated reference.** Sources are already rich enough: `.env.reference` carries 353 variables
+across 52 banner sections with per-variable prose, defaults, constraints, `[derived]`/`[independent]`/
+`[federation]`/`[deprecated]` markers and explicit `(config.key.path)` back-references;
+`config.defaults.yaml` carries ~210 `<%= ENV['X'] %>` key↔var mappings. **Reuse the existing pipeline
+rather than inventing a second one** — `src/components/config-generator/schemas/` already vendors JSON
+Schemas generated in the app repo by `pnpm run schemas:json:generate`, with env mappings curated in
+`presets.ts`. The generator emits to the docs repo; CI fails on drift.
+
+Worth noting: `docs/templates/README.md` already mandates a four-type content model (Concept guide /
+How-to / Reference / Architecture note) with a `Source of truth:` field and the rule "GENERATE OR
+TABLE-DRIVE reference where possible… rather than hand-maintaining a parallel copy that will drift."
+Only two of 61 pages follow it. This plan is largely **making the published tree express the model the
+repo already documents.**
+
+---
+
+## Decisions needed
+
+1. **Per-region pages: merge or keep?** Merging five 43–47 line templates into one comparison page
+   kills ~80 translation obligations, but those URLs plausibly carry SEO value ("onetimesecret EU data
+   residency") and get cited in compliance questionnaires. Redirects preserve the URLs, but a redirect
+   is not a landing page. Marketing/SEO call, not a docs call.
+2. **Caddy on-demand TLS: document the limitation, fix it, or remove the option?**
+   `caddy_on_demand_strategy.rb:61` returns `is_resolving: nil`, so `ready?` is never true and the ask
+   endpoint 403s every domain — no certificate is ever issued. It is currently listed as a supported
+   strategy with no warning. Same question for three other flagged defects: the DLQ consumer silently
+   discarding secret links and expiration warnings; `JOBS_SCHEDULER_ENABLED` / `JOBS_FALLBACK_SYNC`
+   being read by no code while `docker-compose.full.yml` tells operators to set them; and
+   `features.domains.strict_strategy` existing in code but in no config file.
+3. **Which billing catalog is authoritative?** `compare-plans.md` promises Identity Plus buyers "Member
+   Invites, up to 50". The only catalog in the repo gives `identity_plus_v1` no `manage_members`
+   entitlement and `total_members_per_org: 1`, with the team tier commented out. Production
+   `etc/billing.yaml` is not in the repo. This determines whether the plan matrix can be generated at
+   all, or must stay hand-maintained with a named owner.
+4. **Is `/audit-events` → `/secret-activity` a supported breaking change?** `CHANGELOG.rst` documents
+   the old path for 0.26.0; routes now serve the new one. Anyone who integrated is broken and nothing
+   public says so. Related: ADR-021, which settles the terminology, is still `status: proposed`.
+5. **Should the operator and reference trees be English-only by policy?** 63 of 115 pages. The
+   empirical case is strong, but it formally tells a German-speaking self-hoster their operator docs
+   will not be translated. Consult the 16 locale maintainers. Middle position: translate the
+   Self-hosting overview and the two decision guides (~5 pages), leave the rest English.
+6. **What happens to the ten stub locales?** `ar`, `ca_ES`, `cs`, `el_GR`, `he`, `hu`, `ru`, `sl_SI`,
+   `vi` and one sibling hold 3 files each, have no i18n bundle, appear in no sidebar map — and are
+   indexed and reachable. Complete or remove? Note the app ships 30 locales to the docs site's 17.
+7. **Who owns the app-repo generator?** Stages 1–3 are commits to `onetimesecret`, not to this repo,
+   and they gate Phase 4. Without a named owner and a backlog slot, the realistic outcome is Phase 4
+   ships hand-written reference pages that drift exactly as the current two have — making the reshape
+   cosmetic. **Highest-risk dependency in the plan.**
+8. **Does the docs site own the end-user "send a secret" layer, or does the product?** Twelve of the
+   highest-traffic proposed pages document a UI that arguably should be self-explanatory. The content
+   demonstrably does not exist anywhere today, but if in-app guidance is planned, these pages should be
+   scoped as its durable linkable reference rather than a duplicate. Settle before Phase 2 — it
+   determines ~12 pages and the entire Tier 1 translation set.
+
+---
+
+## Appendix A — corrections applied during the audit
+
+An adversarial verifier was tasked with refuting every claimed gap. It refuted **20 of them**, and
+found one systemic error worth recording:
+
+**The audit's initial scope boundary was wrong.** `src/pages/en/self-hosting/configuration-generator.astro`
+is a published page, sits in the sidebar, and is promoted by tip callouts atop *both* big reference
+pages — but it is not in `src/content/docs/en/`, so every domain surveyor missed it. Its option manifest
+(`src/components/config-generator/presets.ts`) renders user-visible labels and descriptions and emits a
+working `.env` starter. Six "zero hits" claims were invalidated outright by it: trusted proxy, AWS SES,
+SendGrid, the emailer mode value set, the Sentry master switch, and the `AUTHENTICATION_MODE`→YAML
+mapping. Fourteen further claims were softened.
+
+That finding has an operational implication beyond this audit: **the Configuration Generator is
+currently the docs site's only accurate published source for several settings whose prose pages are
+stale.** Any future coverage check must scope on the sitemap, not the content directory.
+
+The core survey survived. The cryptography domain in particular was not dented: `SECRET_PREVIOUS`,
+`SECRET_VERIFIER_MODE`, `ACCOUNT_ID_SECRET`, `AUTH_OLD_SECRET` and the fail-safe-reveal behaviour are
+genuinely at zero hits, each independently confirmed against source. Two claims turned out **worse**
+than first reported: `install.sh` genuinely does not exist despite four invocations in the docs, and
+the `TTL_OPTIONS` separator error is a confirmed silent data-loss defect.
+
+A completeness critic then found **19 features and 13 IA weaknesses** the surveys and the first IA
+draft had missed — clustered exactly where no survey domain owned the question (runtime/capacity,
+container artifacts, stateful upgrade, account lifecycle, revenue operations). All 19 features and all
+13 critiques are folded into the tree above; they account for `operate/scale-and-tune`,
+`operate/datastore`, `install/images-and-variants`, `upgrades/data-migrations`,
+`account/change-your-email`, `account/close-your-account`, `account/dashboard-and-recent-secrets`,
+`start/glossary`, `features/feedback-channel`, `features/broadcast-banner`, the promotion of API to
+top level, the relocation of the hardening checklist, the retitling of the config-key pages, and the
+"Reference owns every default" rule.
+
+---
+
+## Appendix B — full topic inventory
+
+See [`documentation-audit-2026-08-topics.md`](./documentation-audit-2026-08-topics.md) — all 304
+undocumented and partial topics, grouped by domain, tagged with priority, status and the env vars each
+covers.

--- a/docs/planning/documentation-audit-2026-08.md
+++ b/docs/planning/documentation-audit-2026-08.md
@@ -392,7 +392,13 @@ repo already documents.**
    and they gate Phase 4. Without a named owner and a backlog slot, the realistic outcome is Phase 4
    ships hand-written reference pages that drift exactly as the current two have — making the reshape
    cosmetic. **Highest-risk dependency in the plan.**
-8. **Does the docs site own the end-user "send a secret" layer, or does the product?** Twelve of the
+8. **Should removed and inert variables be published at all?** The deprecated/removed/inert reference
+   page is what makes `DEPRECATED_CONFIG_MODE=strict` survivable, and it prevents the
+   silent-misconfiguration class — setting a variable that looks right and does nothing. Against: it
+   publishes a precise inventory of what older versions read, and names variables that exist in the
+   codebase but are not wired up. Low risk and high operational value in our assessment, but it is a
+   security-posture call for whoever owns `SECURITY.md`, not a docs call.
+9. **Does the docs site own the end-user "send a secret" layer, or does the product?** Twelve of the
    highest-traffic proposed pages document a UI that arguably should be self-explanatory. The content
    demonstrably does not exist anywhere today, but if in-app guidance is planned, these pages should be
    scoped as its durable linkable reference rather than a duplicate. Settle before Phase 2 — it

--- a/docs/planning/documentation-audit-2026-08.md
+++ b/docs/planning/documentation-audit-2026-08.md
@@ -59,8 +59,11 @@ copy-drift with better writing, only by deleting the copy** — which is why the
 generated reference.
 
 Two live navigation defects found while mapping: `sidebar.mjs:217` links a path with no backing
-content-collection file, and `sidebar.mjs:255` links `translations/universal`, whose only file is
-`_index.md` — which Astro content collections skip.
+content-collection file, and `sidebar.mjs:251` links `translations/universal`, whose landing page is
+named `_index.md` — and Astro content collections skip underscore-prefixed files, so the section has no
+index to resolve to. Its five sibling guidance pages (`voice-and-tone.md`, `quality-checklist.md`,
+`brand-terms.md`, `secret-concept.md`, `password-passphrase.md`) do exist and do build, but the sidebar
+links only the unresolvable parent, leaving all five unreachable from navigation.
 
 ---
 


### PR DESCRIPTION
## What changed

Added two comprehensive planning documents that audit the current state of the documentation:

1. **`documentation-audit-2026-08.md`** — A 439-line audit report that catalogs documentation gaps, identifies factually incorrect published statements, and proposes a complete information architecture restructure. Key findings:
   - **305 features catalogued**, of which **183 are undocumented** and **121 are only partially documented**
   - **~25 published statements are factually wrong** (e.g., `TTL_OPTIONS` separator, `CSP_ENABLED` default, incorrect command names, removed features still documented)
   - **61 published pages → 115 proposed pages** across 8 top-level sections (down from 14)
   - Proposes a 5-phase implementation plan with sequencing and decision points

2. **`documentation-audit-2026-08-topics.md`** — A 333-line companion inventory of all 304 catalogued features grouped by domain (secrets/crypto, HTTP security, authentication, email, jobs, observability, custom domains, organizations/billing, branding/i18n), tagged by priority and documentation status.

## Rationale

These are planning documents, not published content. They:
- Document the methodology and findings of a systematic audit across 9 parallel domain surveys
- Identify critical defects (wrong commands, removed features still published, missing TXT DNS step that breaks custom domains)
- Propose concrete IA changes with implementation mechanics and sequencing
- Record corrections made during adversarial verification passes
- Establish decision points for stakeholders (per-region page strategy, operator-tree translation policy, billing catalog authority, etc.)

The audit was conducted against the product's full configuration surface (`.env.reference`, config defaults, 194 internal specs/ADRs, implementation code) compared against 61 published English pages.

## Page taxonomy

- [x] N/A — these are planning/audit documents, not user-facing pages. They live in `docs/planning/` and are not part of the published site.

## Checklist

- [x] No internal links to check (planning documents only)
- [x] No sidebar or translation keys affected
- [x] No new published pages introduced in this PR

https://claude.ai/code/session_01DdijiDNmvDzRKzJZcFzCHx