### PR TITLE
Add the required TXT ownership record to the custom domain setup guide

### DIFF
--- a/src/content/docs/en/custom-domains/dns-validation.md
+++ b/src/content/docs/en/custom-domains/dns-validation.md
@@ -6,9 +6,9 @@ description: How Onetime Secret verifies your custom domain's DNS configuration,
 ## What is DNS validation?
 
 After you add a custom domain and create the required DNS records, Onetime
-Secret needs to confirm that those records point to the correct region endpoint
-before it can issue an SSL certificate and start serving your domain. That
-confirmation step is **DNS validation**.
+Secret needs to confirm that you own the domain and that your records point to
+the correct region endpoint before it can issue an SSL certificate and start
+serving your domain. That confirmation step is **DNS validation**.
 
 This page focuses on the _validation lifecycle_. For creating the records in the
 first place — CNAME vs. A records, per-region targets, and apex vs. subdomain
@@ -16,8 +16,8 @@ guidance — see the [Setup Guide](/en/custom-domains/setup-guide).
 
 ## The validation lifecycle
 
-1. **Records created** — You add the CNAME (subdomain) or A record (apex) shown in your Domain Dashboard for your chosen [region](/en/regions).
-2. **Verification** — Onetime Secret automatically attempts to verify the domain. You can use the **Verify** button to expedite the check; you may need to refresh the page.
+1. **Records created** — You add the two records shown in your Domain Dashboard: the TXT ownership record, plus the CNAME (subdomain) or A record (apex) for your chosen [region](/en/regions). They can be created in either order.
+2. **Verification** — Onetime Secret automatically re-checks the domain on a schedule (roughly every 30 minutes), and you can use the **Verify** button to expedite the check; you may need to refresh the page. Every pass checks both the TXT ownership record and your CNAME/A record.
 3. **SSL issuance** — Once verification succeeds, SSL certificate generation begins automatically. This usually takes a few minutes.
 4. **Active** — When complete, the dashboard shows **Active with SSL**, the target address for your region, an SSL status of **Active**, and an SSL renewal date.
 
@@ -34,7 +34,8 @@ Your Domain Dashboard reflects where the domain is in this lifecycle:
 If validation does not succeed, work through the following:
 
 - **Wrong or missing record** — Double-check the record type, host, and target value against the [Setup Guide](/en/custom-domains/setup-guide) for your specific region.
-- **Conflicting records** — Remove any existing A, AAAA, or CNAME records for the same host that conflict with the one you added.
+- **Missing TXT record** — Verification checks both the TXT ownership record and your CNAME/A record; a correct CNAME/A with a missing TXT record will never verify, even if SSL has been issued and the domain appears to work. Copy the TXT record's host and value from your Domain Dashboard.
+- **Conflicting records** — Remove any existing A, AAAA, or CNAME records for the same host that conflict with the one you added. Never remove the TXT ownership record — it must stay in place before and after verification.
 - **Propagation delay** — DNS changes may take up to 24–48 hours to fully propagate. If verification fails initially, wait and try again.
 - **Apex domain limitations** — Apex (root) domains cannot use CNAME records and must use A records; confirm you are using the correct record type.
 - **Domain ownership** — Make sure you have full control of the domain and its DNS settings.

--- a/src/content/docs/en/custom-domains/how-it-works.md
+++ b/src/content/docs/en/custom-domains/how-it-works.md
@@ -22,7 +22,7 @@ By leveraging Custom Domains, you're not just sharing secrets; you're reinforcin
 
 ## Troubleshooting Common Setup Issues
 
-- **DNS Propagation**: Changes may take up to 48 hours to fully propagate. Be patient and try again later if verification fails initially.
+- **DNS Propagation**: Changes may take up to 24–48 hours to fully propagate. Be patient and try again later if verification fails initially.
 - **Incorrect DNS Records**: Double-check your DNS settings against the provided instructions for your chosen region.
 - **SSL Certificate Issues**: Contact our support team if you encounter any SSL-related problems.
 - **Domain Ownership Verification**: Ensure you have full control over the domain you're trying to set up.

--- a/src/content/docs/en/custom-domains/setup-guide.md
+++ b/src/content/docs/en/custom-domains/setup-guide.md
@@ -47,12 +47,14 @@ Your Domain Dashboard lists this record first, before the routing record, and sh
 
 1. Access your domain's DNS management panel (through your domain registrar or DNS provider)
 2. Create a TXT record, copying the Host and Value exactly as shown in your Domain Dashboard:
-   - Host: `_onetime-challenge-<id>`, where `<id>` is a short identifier unique to your domain
+   - Host: `_onetime-challenge-<id>` for an apex domain, or `_onetime-challenge-<id>.<subdomain>` for a subdomain, where `<id>` is a short identifier unique to your domain
      - For an apex domain (e.g., example.com): `_onetime-challenge-abc1234`
      - For a subdomain (e.g., secrets.example.com): `_onetime-challenge-abc1234.secrets` — the record is created on the base domain's zone (example.com)
-   - Value: the unique 32-character code shown in your dashboard
+   - Value: the unique 32-character hexadecimal code shown in your dashboard
 
 The host and value above show the shape only — your actual record is unique to your domain and must be copied from your Domain Dashboard. The value never rotates or expires.
+
+Registrars display record hosts differently: some expect just the label (and append the zone for you), others expect the fully qualified name. If your provider's form does not accept the host as shown, match its convention — the value from your Domain Dashboard is what must resolve.
 
 Ownership verification cannot complete without this record, and it must stay in place after verification — do not remove it.
 
@@ -126,7 +128,7 @@ Once setup is complete, you should see the following information:
 - If verification fails, double-check your DNS settings
 - Confirm the TXT ownership record exists — verification cannot complete without it, even if the domain appears to work
 - Ensure you've removed any conflicting records (but never the TXT ownership record)
-- DNS propagation can take up to 24 hours, though it's usually much faster
+- DNS propagation can take up to 24–48 hours, though it's usually much faster
 
 ## Using Your Custom Domain
 

--- a/src/content/docs/en/custom-domains/setup-guide.md
+++ b/src/content/docs/en/custom-domains/setup-guide.md
@@ -46,7 +46,7 @@ To connect your domain, you need to create exactly two DNS records: a TXT record
 Your Domain Dashboard lists this record first, before the routing record, and shows the exact Type, Host, and Value to copy.
 
 1. Access your domain's DNS management panel (through your domain registrar or DNS provider)
-2. Create a TXT record, copying the Host and Value exactly as shown in your Domain Dashboard:
+2. Create a TXT record, copying the Value exactly as shown in your Domain Dashboard and entering the Host in your registrar's expected form:
    - Host: `_onetime-challenge-<id>` for an apex domain, or `_onetime-challenge-<id>.<subdomain>` for a subdomain, where `<id>` is a short identifier unique to your domain
      - For an apex domain (e.g., example.com): `_onetime-challenge-abc1234`
      - For a subdomain (e.g., secrets.example.com): `_onetime-challenge-abc1234.secrets` — the record is created on the base domain's zone (example.com)
@@ -54,7 +54,7 @@ Your Domain Dashboard lists this record first, before the routing record, and sh
 
 The host and value above show the shape only — your actual record is unique to your domain and must be copied from your Domain Dashboard. The value never rotates or expires.
 
-Registrars display record hosts differently: some expect just the label (and append the zone for you), others expect the fully qualified name. If your provider's form does not accept the host as shown, match its convention — the value from your Domain Dashboard is what must resolve.
+Registrars display record hosts differently: some expect just the label (and append the zone for you), others expect the fully qualified name. Enter the host in whichever form your provider expects — what matters is that the resulting record resolves at `<host>.<your base domain>` and returns the dashboard value unchanged.
 
 Ownership verification cannot complete without this record, and it must stay in place after verification — do not remove it.
 

--- a/src/content/docs/en/custom-domains/setup-guide.md
+++ b/src/content/docs/en/custom-domains/setup-guide.md
@@ -41,6 +41,11 @@ Consider your specific needs and requirements when making this choice. For more 
 
 To connect your domain, you need to create exactly two DNS records: a TXT record that verifies you own the domain, and a routing record (CNAME for subdomains, A for apex domains). You can create them in either order. The routing record differs slightly depending on whether you're using a subdomain or an apex domain, and which data center region you choose.
 
+<!-- LOCALE DRIFT (2026-08): This TXT ownership section (and the related mentions in
+Steps 3–4 and Troubleshooting, plus the 24–48h propagation window) exists only in this
+EN page. The 16 locale copies of setup-guide.md lack the section entirely and still say
+"24 hours". Remove this comment once the locales are re-synced. -->
+
 ### Create the Ownership Verification TXT Record (All Domains)
 
 Your Domain Dashboard lists this record first, before the routing record, and shows the exact Type, Host, and Value to copy.

--- a/src/content/docs/en/custom-domains/setup-guide.md
+++ b/src/content/docs/en/custom-domains/setup-guide.md
@@ -39,7 +39,22 @@ Consider your specific needs and requirements when making this choice. For more 
 
 ## Step 3: Configure DNS Settings
 
-To connect your domain, you need to update your DNS settings. The process differs slightly depending on whether you're using a subdomain or an apex domain, and which data center region you choose.
+To connect your domain, you need to create exactly two DNS records: a TXT record that verifies you own the domain, and a routing record (CNAME for subdomains, A for apex domains). You can create them in either order. The routing record differs slightly depending on whether you're using a subdomain or an apex domain, and which data center region you choose.
+
+### Create the Ownership Verification TXT Record (All Domains)
+
+Your Domain Dashboard lists this record first, before the routing record, and shows the exact Type, Host, and Value to copy.
+
+1. Access your domain's DNS management panel (through your domain registrar or DNS provider)
+2. Create a TXT record, copying the Host and Value exactly as shown in your Domain Dashboard:
+   - Host: `_onetime-challenge-<id>`, where `<id>` is a short identifier unique to your domain
+     - For an apex domain (e.g., example.com): `_onetime-challenge-abc1234`
+     - For a subdomain (e.g., secrets.example.com): `_onetime-challenge-abc1234.secrets` — the record is created on the base domain's zone (example.com)
+   - Value: the unique 32-character code shown in your dashboard
+
+The host and value above show the shape only — your actual record is unique to your domain and must be copied from your Domain Dashboard. The value never rotates or expires.
+
+Ownership verification cannot complete without this record, and it must stay in place after verification — do not remove it.
 
 ### For Subdomains (Recommended)
 
@@ -52,7 +67,7 @@ To connect your domain, you need to update your DNS settings. The process differ
      - For NZ region: identity.nz.onetime.co
      - For UK region: identity.ingress.onetime.co (anycast)
      - For US region: identity.us.onetime.co
-3. Remove any existing A, AAAA, or CNAME records for the same subdomain
+3. Remove any existing A, AAAA, or CNAME records for the same subdomain — but keep the TXT ownership record
 
 ### For Apex Domains
 
@@ -64,7 +79,7 @@ To connect your domain, you need to update your DNS settings. The process differ
      - For US region: 66.51.126.41
      - For other regions: Contact support for current A record IP addresses
 
-Important: Ensure there are no conflicting records for the domain you're using.
+Important: Ensure there are no conflicting A, AAAA, or CNAME records for the domain you're using. The TXT ownership record is not a conflict — leave it in place.
 
 <img src="/img/docs/custom-domains/4-Custom-domain-settings.png" alt="Custom domain settings" width="400" />
 
@@ -86,10 +101,13 @@ Apex domains cannot use CNAME records due to DNS standards. Therefore, we must u
 
 ## Step 4: Verify Domain and Wait for SSL
 
-1. After updating DNS settings, return to the Onetime Secret custom domain page
-2. The system will automatically attempt to verify your domain
-3. SSL certificate generation will begin once verification is successful
-4. This process may take a few minutes to complete
+1. After creating both DNS records, return to the Onetime Secret custom domain page
+2. Press the "Verify" button to check your records right away — verification also re-runs automatically about every 30 minutes
+3. Every verification pass checks both records: the TXT ownership record and your CNAME or A record
+4. SSL certificate generation will begin once verification is successful
+5. This process may take a few minutes to complete
+
+Note: a correct CNAME or A record alone will never verify. SSL may already be issued and your domain may appear to work, but ownership verification cannot complete until the TXT record is in place.
 
 For a closer look at the verification lifecycle, what each domain status means,
 and how to resolve a failed check, see [DNS Validation](/en/custom-domains/dns-validation).
@@ -106,7 +124,8 @@ Once setup is complete, you should see the following information:
 ## Troubleshooting
 
 - If verification fails, double-check your DNS settings
-- Ensure you've removed any conflicting records
+- Confirm the TXT ownership record exists — verification cannot complete without it, even if the domain appears to work
+- Ensure you've removed any conflicting records (but never the TXT ownership record)
 - DNS propagation can take up to 24 hours, though it's usually much faster
 
 ## Using Your Custom Domain


### PR DESCRIPTION
Part of the August 2026 documentation audit, Phase 1 — the single most expensive gap on the site: `TXT` had zero hits across the entire `en/` tree while the product requires a TXT ownership record for domain verification to complete.

Verified against app source this session: when a domain is added, the server generates a `_onetime-challenge-<id>` TXT challenge (32-char value, shown first in the Domain Dashboard, exposed by the domains API); every verification pass checks both the TXT record and the CNAME/A routing record; ownership verification **cannot complete without the TXT record** — a correct CNAME/A alone never verifies, even with SSL already issued and the domain appearing to work. The record never rotates or expires and must stay in place.

Changes (EN only):
- `setup-guide.md` — Step 3 now states exactly two records are required and gains **Create the Ownership Verification TXT Record (All Domains)** before the subdomain/apex sections, mirroring the dashboard's ordering; host/value shown as shape-only placeholders (real values must be copied from the dashboard). Conflicting-record guidance now explicitly excludes the TXT record. Step 4 documents the real lifecycle: Verify button + automatic ~30-minute rechecks, both records checked every pass.
- `dns-validation.md` — lifecycle now includes the TXT record; new troubleshooting item for the missing-TXT case (the "stuck pending forever" scenario).

Locale copies untouched — translation follow-up.

`pnpm build` green (1069 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)