### PR TITLE
Document audit decisions and revise plan for Phase 1–5

### DIFF
--- a/docs/planning/documentation-audit-2026-08-topics.md
+++ b/docs/planning/documentation-audit-2026-08-topics.md
@@ -14,9 +14,11 @@ Fully-documented features are omitted. 304 topics follow.
 still a gap. What changed for a handful of topics is *who resolves them and when*, so those lines carry
 a trailing marker:
 
-- **[D2]** — a code-side defect, not a writing task. Tracked in
-  [onetimesecret#3993](https://github.com/onetimesecret/onetimesecret/issues/3993); the docs describe
-  current behaviour and do not claim the feature works.
+- **[D2]** — the underlying defect is code-side and tracked in
+  [onetimesecret#3993](https://github.com/onetimesecret/onetimesecret/issues/3993), so no amount of
+  writing will resolve it. These topics still get written: the docs owe an accurate account of current
+  behaviour, which for these means stating plainly that the feature does not work as its configuration
+  suggests. What the marker rules out is documenting them as if they did.
 - **[D3]** — blocked on the production `etc/billing.yaml`, which is kept outside both repos and
   requested when needed. Cannot be written from in-repo sources.
 - **[D8]** — no dedicated deprecated/removed reference page; the project is pre-1.0 and the reference

--- a/docs/planning/documentation-audit-2026-08-topics.md
+++ b/docs/planning/documentation-audit-2026-08-topics.md
@@ -10,6 +10,22 @@ identifiers are the environment variables the topic covers, truncated to four.
 
 Fully-documented features are omitted. 304 topics follow.
 
+**Decision annotations (2026-08-04).** Priority and status are unchanged by the decisions — a gap is
+still a gap. What changed for a handful of topics is *who resolves them and when*, so those lines carry
+a trailing marker:
+
+- **[D2]** — a code-side defect, not a writing task. Tracked in
+  [onetimesecret#3993](https://github.com/onetimesecret/onetimesecret/issues/3993); the docs describe
+  current behaviour and do not claim the feature works.
+- **[D3]** — blocked on the production `etc/billing.yaml`, which is kept outside both repos and
+  requested when needed. Cannot be written from in-repo sources.
+- **[D8]** — no dedicated deprecated/removed reference page; the project is pre-1.0 and the reference
+  documents what the current version reads. The marker records where the topic goes instead, which for
+  most of these is *nowhere for now*.
+
+Everything unmarked proceeds as the plan describes. See
+[`documentation-audit-2026-08.md`](./documentation-audit-2026-08.md#decisions) for the full reasoning.
+
 ### Secrets, cryptography & key management
 - [crit/partia] SECRET as root input keying material (IKM) — the HKDF key tree — SECRET
 - [crit/partia] Three key classes: [derived] vs [independent] vs [federation] — SESSION_SECRET,IDENTIFIER_SECRET,AUTH_SECRET,ARGON2_SECRET
@@ -40,7 +56,7 @@ Fully-documented features are omitted. 304 topics follow.
 - [medi/partia] At-most-once reveal guarantee (fail-closed, not fail-open)
 - [medi/undocu] Uniform 'no longer available' response — the deliberate absence of an existence oracle
 - [medi/undocu] Reads are state-neutral: viewing does not reset expiration or advance state
-- [low/undocu] RODAUTH_HMAC_SECRET — deprecated and silently ignored — RODAUTH_HMAC_SECRET
+- [low/undocu] RODAUTH_HMAC_SECRET — deprecated and silently ignored — RODAUTH_HMAC_SECRET **[D8: deferred]**
 - [low/undocu] SECRET_VARIABLE_NAMES — routing secrets to Podman/container secret stores — SECRET_VARIABLE_NAMES
 
 ### HTTP security, sessions, middleware & network
@@ -111,8 +127,8 @@ Fully-documented features are omitted. 304 topics follow.
 - [medi/partia] Simple mode: what it actually supports
 - [low/partia] Per-provider SSO display names and the deprecated SSO_DISPLAY_NAME — SSO_DISPLAY_NAME,OIDC_DISPLAY_NAME,ENTRA_DISPLAY_NAME,GOOGLE_DISPLAY_NAME
 - [low/partia] TOTP authenticator issuer label (BRAND_TOTP_ISSUER) — BRAND_TOTP_ISSUER,BRAND_PRODUCT_NAME,SITE_NAME
-- [low/undocu] AUTH_SERVICE_URL (reserved / inert) — AUTH_SERVICE_URL
-- [low/undocu] Deprecated and inert auth variables (RODAUTH_HMAC_SECRET, GITHUB_KEY/SECRET, GOOGLE_KEY/SECRET) — RODAUTH_HMAC_SECRET,GITHUB_KEY,GITHUB_SECRET,GOOGLE_KEY
+- [low/undocu] AUTH_SERVICE_URL (reserved / inert) — AUTH_SERVICE_URL **[D8: deferred]**
+- [low/undocu] Deprecated and inert auth variables (RODAUTH_HMAC_SECRET, GITHUB_KEY/SECRET, GOOGLE_KEY/SECRET) — RODAUTH_HMAC_SECRET,GITHUB_KEY,GITHUB_SECRET,GOOGLE_KEY **[D8: deferred]**
 
 ### Email delivery, providers & deliverability
 - [crit/partia] Email delivery mode / transport selection (emailer.mode) — EMAILER_MODE
@@ -155,11 +171,11 @@ Fully-documented features are omitted. 304 topics follow.
 - [crit/partia] Running the scheduler daemon — SCHEDULER_PID_PATH
 - [high/undocu] RabbitMQ TLS (amqps) configuration — RABBITMQ_VERIFY_PEER,RABBITMQ_CA_CERTIFICATES
 - [high/partia] Queue and exchange provisioning (ots queue init) — RABBITMQ_MANAGEMENT_URL
-- [high/undocu] JOBS_SCHEDULER_ENABLED does not gate the scheduler — JOBS_SCHEDULER_ENABLED
-- [high/undocu] Fallback delivery when the broker is unavailable — JOBS_FALLBACK_SYNC
+- [high/undocu] JOBS_SCHEDULER_ENABLED does not gate the scheduler — JOBS_SCHEDULER_ENABLED **[D2]**
+- [high/undocu] Fallback delivery when the broker is unavailable — JOBS_FALLBACK_SYNC **[D2]**
 - [high/undocu] Dead-letter queue inspection, replay and purge
 - [high/undocu] Dead-letter queue 7-day message TTL
-- [high/undocu] DLQ email consumer job (auth-email rescue)
+- [high/undocu] DLQ email consumer job (auth-email rescue) — non-auth mail, incl. secret links and expiration warnings, is discarded by design **[D2: documented in operate/queues-and-dlq, not fixed]**
 - [high/undocu] Queue reset and the immutable-queue-arguments hazard
 - [high/undocu] Plan cache refresh job
 - [high/undocu] Secret expiration warning emails
@@ -167,7 +183,7 @@ Fully-documented features are omitted. 304 topics follow.
 - [high/undocu] Index rebuild maintenance job
 - [high/undocu] Instances rebuild maintenance job
 - [high/undocu] Secret count reconciliation job
-- [high/undocu] Removal of the 32 JOBS_* tuning environment variables in v0.26 — JOBS_EXPIRATION_WARNINGS_ENABLED,JOBS_DLQ_CONSUMER_ENABLED,JOBS_DOMAIN_REFRESH_ENABLED,JOBS_MAINTENANCE_ENABLED
+- [high/undocu] Removal of the 32 JOBS_* tuning environment variables in v0.26 — JOBS_EXPIRATION_WARNINGS_ENABLED,JOBS_DLQ_CONSUMER_ENABLED,JOBS_DOMAIN_REFRESH_ENABLED,JOBS_MAINTENANCE_ENABLED **[D8: → upgrades/v0-26 + troubleshoot/boot-failures]**
 - [medi/undocu] Per-worker concurrency and prefetch tuning — EMAIL_WORKER_THREADS,EMAIL_WORKER_PREFETCH,NOTIFICATION_WORKER_THREADS,NOTIFICATION_WORKER_PREFETCH
 - [medi/undocu] Publisher channel pool sizing — RABBITMQ_CHANNEL_POOL_SIZE
 - [medi/undocu] Queue topology reference
@@ -228,7 +244,7 @@ Fully-documented features are omitted. 304 topics follow.
 - [crit/partia] Domain validation strategy: choosing between passthrough / approximated / caddy_on_demand — DOMAINS_VALIDATION_STRATEGY
 - [crit/undocu] passthrough strategy accepts any domain string with zero ownership proof — DOMAINS_VALIDATION_STRATEGY,DOMAINS_REQUIRE_VERIFIED
 - [crit/undocu] Require verified domain before secret creation (DOMAINS_REQUIRE_VERIFIED) — DOMAINS_REQUIRE_VERIFIED
-- [crit/undocu] caddy_on_demand currently refuses every certificate (ask endpoint returns 403 for all domains) — DOMAINS_VALIDATION_STRATEGY,ACME_ENDPOINT_ENABLED
+- [crit/undocu] caddy_on_demand currently refuses every certificate (ask endpoint returns 403 for all domains) — DOMAINS_VALIDATION_STRATEGY,ACME_ENDPOINT_ENABLED **[D2]**
 - [crit/undocu] The TXT ownership challenge record (_onetime-challenge-…)
 - [crit/undocu] INCOMING_ENABLED does not gate custom domains (canonical/custom split) — INCOMING_ENABLED,ORGS_INCOMING_SECRETS_ENABLED
 - [high/partia] Custom domains master switch (enable the feature at all) — DOMAINS_ENABLED
@@ -237,7 +253,7 @@ Fully-documented features are omitted. 304 topics follow.
 - [high/undocu] Blocking the internal ACME endpoint at the reverse proxy — ACME_ENDPOINT_ENABLED
 - [high/partia] Approximated provider configuration (API key and vhost target) — APPROXIMATED_API_KEY,APPROXIMATED_VHOST_TARGET
 - [high/partia] Cluster proxy settings drive the DNS instructions shown to your customers — APPROXIMATED_PROXY_IP,APPROXIMATED_PROXY_HOST,APPROXIMATED_PROXY_NAME
-- [high/undocu] Unknown validation_strategy silently downgrades to passthrough (features.domains.strict_strategy)
+- [high/undocu] Unknown validation_strategy silently downgrades to passthrough (features.domains.strict_strategy) **[D2]**
 - [high/partia] Reverse-proxy requirements for serving tenant hostnames
 - [high/partia] Homepage secrets mode: private landing page / create form / incoming form
 - [high/partia] Multi-region deployment: REGIONS_ENABLED, JURISDICTION, JURISDICTIONS — REGIONS_ENABLED,JURISDICTION,JURISDICTIONS
@@ -253,7 +269,7 @@ Fully-documented features are omitted. 304 topics follow.
 - [medi/undocu] Domain context override for local testing (DOMAIN_CONTEXT_ENABLED) — DOMAIN_CONTEXT_ENABLED,DOMAIN_CONTEXT
 - [medi/partia] Who may create a secret on a custom domain (domain permission matrix)
 - [medi/partia] Cross-region subscription federation (FEDERATION_SECRET) — FEDERATION_SECRET
-- [medi/undocu] Deprecated regions/domains config paths (site.regions, site.domains, array-form jurisdictions)
+- [medi/undocu] Deprecated regions/domains config paths (site.regions, site.domains, array-form jurisdictions) **[D8: deferred]**
 - [medi/partia] Incoming memo length and TTL — and why custom domains ignore your setting — INCOMING_MEMO_MAX_LENGTH,INCOMING_DEFAULT_TTL
 - [medi/partia] Enabling per-domain incoming for organizations (ORGS_INCOMING_SECRETS_ENABLED) — ORGS_INCOMING_SECRETS_ENABLED
 - [low/undocu] Approximated DNS widget (auto-detect the customer's DNS provider)
@@ -293,7 +309,7 @@ Fully-documented features are omitted. 304 topics follow.
 - [low/undocu] Help modal on secret pages (HELP_ENABLED) — HELP_ENABLED
 - [low/partia] Web UI master switch (UI_ENABLED) — UI_ENABLED
 - [low/undocu] PWA web manifest branding (/site.webmanifest) — BRAND_PRODUCT_NAME,BRAND_PRIMARY_COLOR
-- [low/undocu] BRAND_PRODUCT_DOMAIN (stored, currently inert) — BRAND_PRODUCT_DOMAIN
+- [low/undocu] BRAND_PRODUCT_DOMAIN (stored, currently inert) — BRAND_PRODUCT_DOMAIN **[D8: deferred]**
 
 ### Organizations, teams, entitlements, billing & admin (colonel)
 - [crit/undocu] The entitlement model (what entitlements are, and the 23-string catalog)
@@ -326,7 +342,7 @@ Fully-documented features are omitted. 304 topics follow.
 - [medi/undocu] Billing background jobs: plan cache refresh, catalog retry, billing worker — BILLING_WORKER_THREADS,BILLING_WORKER_PREFETCH,JOBS_SCHEDULER_ENABLED
 - [medi/undocu] System role hierarchy: colonel, admin, staff, customer
 - [medi/undocu] Colonel audit trail (ColonelAuditEvent)
-- [medi/partia] Plan tier → entitlement mapping shown to buyers
+- [medi/partia] Plan tier → entitlement mapping shown to buyers — hand-maintained, needs a named owner **[D3]**
 - [medi/undocu] Control plane vs data plane: admin surfaces are canonical-domain only (planned) — CANONICAL_DOMAIN,DEFAULT_DOMAIN
 - [low/undocu] Colonel plan-preview mode (request-scoped entitlement preview)
 - [low/undocu] Complimentary and pro-bono plans

--- a/docs/planning/documentation-audit-2026-08.md
+++ b/docs/planning/documentation-audit-2026-08.md
@@ -14,10 +14,11 @@ adversarial verifier tasked with *refuting* every claimed gap and a completeness
 finding what the surveys missed. Both adversarial passes landed hits; their corrections are applied
 below and recorded in Appendix A rather than quietly dropped.
 
-**Status — revised 2026-08-04.** The nine decisions this audit raised have been answered. Eight are
-settled; their consequences are applied throughout the plan below and the reasoning is recorded in
-[Decisions](#decisions). One — who owns the end-user task layer — remains open and gates five pages in
-Phase 2; an interim posture is defined so nothing else waits on it.
+**Status — revised 2026-08-04.** All nine decisions this audit raised now have a recorded response.
+Eight of those responses **settle** the question, and their consequences are applied throughout the plan
+below; the ninth — who owns the end-user task layer — responded without settling it, so D9 stays **open**
+and gates five pages in Phase 2. An interim posture is defined so nothing else waits on it. The
+reasoning for all nine is in [Decisions](#decisions).
 
 ---
 
@@ -178,7 +179,7 @@ marketing site. Its current paid CTA points at `pricing/index.md`, which is an o
 | | Page | Covers |
 |---|---|---|
 |`MRG`|`start/index`|absorbs `docs-overview` + `introduction/index` + `introduction/guides`|
-|`NEW`|`start/send-your-first-secret` **†**|the product's core action, end to end — gated on [D9](#d9--who-owns-the-end-user-task-layer-open)|
+|`NEW`|`start/send-your-first-secret` **†**|the product's core action, end to end — gated on [D9](#d9--who-owns-the-end-user-task-layer)|
 |`MRG`|`start/run-your-own-instance`|absorbs `self-hosting/getting-started`|
 |`MOV`|`start/hosted-or-self-hosted`|from `self-hosting/self-hosting-vs-hosted`|
 |`NEW`|`start/glossary`|receipt vs private link vs metadata; passphrase vs password; organization vs workspace vs team; colonel vs admin vs staff; entitlement vs permission vs capability; Secret Activity vs Security Events; canonical vs custom domain|
@@ -188,7 +189,7 @@ inside long pages, reachable only by already knowing which page hides them.
 
 #### 3. Using Onetime Secret · 30 pages
 
-Pages marked **†** are gated on [D9](#d9--who-owns-the-end-user-task-layer-open). Eleven of the twelve
+Pages marked **†** are gated on [D9](#d9--who-owns-the-end-user-task-layer). Eleven of the twelve
 contested end-user pages are in this section — the twelfth, `start/send-your-first-secret`, is in *Start
 here* and is also gated — and the seven unmarked ones proceed regardless of how D9 lands. The rule that
 separates them is stated after *Your account*.
@@ -237,7 +238,7 @@ ownership step**) · `UPD custom-domains/dns-validation` · `MOV custom-domains/
 **Plans & billing** (2) — `MRG billing/index` (de-orphans `pricing/index`, absorbs `compare-plans`) ·
 `NEW billing/managing-your-subscription`
 
-> Per [D3](#d3--billing-catalog-settled), the plan matrix is **hand-maintained with a named owner** and
+> Per [D3](#d3--billing-catalog), the plan matrix is **hand-maintained with a named owner** and
 > is explicitly out of the generated reference's scope. Its source of truth is the production
 > `etc/billing.yaml`, which lives outside both repos and is requested when a docs task needs it.
 > `etc/examples/billing.example.yaml` is an example file and cannot arbitrate what buyers are sold.
@@ -263,7 +264,7 @@ surfaces with no hosted counterpart, which fell out of the first draft precisely
 organised as an audience mirror: `NEW features/feedback-channel` · `NEW features/broadcast-banner`
 
 > `features/caddy-on-demand-tls` must not be written as a working strategy. Per
-> [D2](#d2--four-code-vs-docs-defects-settled), `caddy_on_demand` currently issues no certificate at all;
+> [D2](#d2--four-code-vs-docs-defects), `caddy_on_demand` currently issues no certificate at all;
 > the page documents the two strategies that work (`passthrough`, `approximated`) and states plainly
 > that the third does not, until the app-repo issue closes. `features/custom-domains` carries the same
 > caveat where it lists strategy choices, and `operate/queues-and-dlq` documents the DLQ consumer's
@@ -303,7 +304,7 @@ CHANGELOG's bolded Action Required migration**, `bin/ots migrate --run 20260703_
 `site-and-interface` · `features-and-branding` · `datastore-and-queues` · `email-and-delivery` ·
 `auth-logging-and-billing-files`
 
-> `reference/deprecated-and-removed` is **cut** per [D8](#d8--removed-and-inert-variables-settled): the
+> `reference/deprecated-and-removed` is **cut** per [D8](#d8--removed-and-inert-variables): the
 > project is pre-1.0 and the reference documents what the current version reads, nothing else. The two
 > jobs that page was carrying still need homes, and both are cheaper than a graveyard inventory. The ~19
 > unsupported variables the site publishes today are **deleted outright** in Phase 1, not relocated —
@@ -318,10 +319,17 @@ CHANGELOG's bolded Action Required migration**, `bin/ots migrate --run 20260703_
 `MOV security/best-practices` · `MRG security/our-principles` (the four principles pages) ·
 `security/vulnerability-disclosure`
 
-> The region merge is settled by [D1](#d1--per-region-pages-settled) in favour of reader experience over
+> The region merge is settled by [D1](#d1--per-region-pages) in favour of reader experience over
 > search ranking. One consequence is worth building for rather than accepting: give
 > `where-your-data-lives` a stable per-region anchor (`#european-union`, `#canada`, …) and point each
-> retired URL at its anchor rather than at the page top. A compliance questionnaire that cites
+> retired URL at its anchor rather than at the page top.
+>
+> That only works if the anchors are what the redirects assume, so pin the contract: **each region's
+> heading text is the bare jurisdiction name and nothing else** — `European Union`, `Canada`,
+> `United Kingdom`, `United States`, `New Zealand`. No "The " prefix, no parenthetical, no "Data
+> residency in …" phrasing. Those five slugify to exactly the five retired filenames, so the redirect
+> targets are derivable rather than hand-matched, and a reviewer can check the contract by reading the
+> headings. A compliance questionnaire that cites
 > `/regions/european-union` then still lands on the EU facts, and the merged page has to carry every
 > per-region fact the five templates carried — jurisdiction, data location, operating entity — or the
 > merge trades away something real. `regions/switching-regions` is not part of the merge; it moves to
@@ -333,12 +341,13 @@ documentation at all. `NEW contribute/developer-on-ramp` (`bin/dev`, `bin/setup 
 containerized test lanes, the 32 ADRs) plus the nine existing translation pages moved, including the
 five currently orphaned under `translations/universal/`.
 
-> This section is guidance *for* translators. It is unaffected by [D5](#d5--translation-policy-settled)
+> This section is guidance *for* translators. It is unaffected by [D5](#d5--translation-policy)
 > deferring translation *of* the site: the contributors it serves are the ones the future initiative
 > will depend on, so its pages stay in the tree and get fixed in Phase 1.
 
-**Totals: 61 pages → 114. ~62 new, ~20 moved, ~14 merged away, 1 deleted.** Of the 62 new pages, five are
-held pending [D9](#d9--who-owns-the-end-user-task-layer-open).
+**Totals: 61 pages → 114. ~62 new, ~20 moved, ~14 merged away, 1 deleted.** Five of the new pages are
+held pending [D9](#d9--who-owns-the-end-user-task-layer); that five is exact, the surrounding counts are
+not.
 
 ---
 
@@ -352,7 +361,7 @@ settable rather than relocating them (per D8); add the missing TXT step to `setu
 `translations/universal/_index.md` → `index.md` to fix the live 404; delete
 `translations/language-notes.md` (an 11-line unfinished `[placeholder]` table) — **all 26 copies**, one
 per locale directory, since every copy is the same unfilled template. That last deletion drops the nine
-stub locales from three files to two, which is consistent with [D6](#d6--stub-locales-settled): it
+stub locales from three files to two, which is consistent with [D6](#d6--stub-locales): it
 neither completes nor removes them.
 
 Two additions from the decisions: the four code-vs-docs defects are filed as
@@ -417,7 +426,7 @@ four — so the `movedPages` entries carry an optional fragment.
 **Translation.** Measured: no locale is at parity (best 41/61; most 36–40), and nine further directories
 hold 3 files each with no i18n bundle and no sidebar entry. The audit proposed a tiered policy —
 translate the end-user surface, make the operator and reference trees English-only by construction.
-[D5](#d5--translation-policy-settled) replaces that with something simpler and more honest about
+[D5](#d5--translation-policy) replaces that with something simpler and more honest about
 sequencing: **English is the only language this plan ships in, and translation is a separate initiative
 scoped after the restructure settles.**
 
@@ -444,7 +453,7 @@ that sidebar entry currently points at something invisible. English-only is a co
 rendering one.
 
 **Stub locales.** The nine 3-file directories (`ar`, `ca_ES`, `cs`, `el_GR`, `he`, `hu`, `ru`, `sl_SI`,
-`vi`) are left in place per [D6](#d6--stub-locales-settled) and revisited with the translation
+`vi`) are left in place per [D6](#d6--stub-locales) and revisited with the translation
 initiative. They stay indexed and reachable, which is a knowingly accepted cost: each holds only
 translation-contributor guidance, so a reader who lands there finds a real page, not a broken product
 doc. If that changes — if the restructure ever routes product content into them — the cheap fix is a
@@ -460,7 +469,7 @@ rather than inventing a second one** — `src/components/config-generator/schema
 Schemas generated in the app repo by `pnpm run schemas:json:generate`, with env mappings curated in
 `presets.ts`. The generator emits to the docs repo; CI fails on drift.
 
-[D7](#d7--generator-ownership-settled) stubs the app-repo half of that pipeline, so the shape changes:
+[D7](#d7--generator-ownership) stubs the app-repo half of that pipeline, so the shape changes:
 the generator lives **in this repo from the start** and reads a **vendored snapshot** of
 `.env.reference` and `config.defaults.yaml` — the same vendoring pattern
 `src/components/config-generator/schemas/` already uses, which is why this is a stub and not a new
@@ -501,9 +510,13 @@ repo already documents.**
 Nine decisions were raised by the audit. Eight are settled and their consequences are applied
 throughout the plan above; one is open. Each entry records the answer as given, then what changed.
 
-### D1 — Per-region pages *(settled)*
+> Keep the settled/open status in the body text, **not** in these headings. The rest of the document
+> deep-links to them by slug, and D9 is expected to move from open to settled before Phase 2 — a status
+> word in the heading would silently break every reference to it at exactly that moment.
 
-**Answer: prioritise developer experience; deprioritise SEO.**
+### D1 — Per-region pages
+
+**Settled — answer:** prioritise developer experience; deprioritise SEO.
 
 The five 43–47 line templates merge into `security/where-your-data-lives`. Applied: the merge is now
 stated as settled rather than conditional; the merged page must carry every per-region fact the
@@ -512,9 +525,9 @@ compliance questionnaire citing `/regions/european-union` still lands on the EU 
 cheap half of what the SEO argument was protecting, and it costs one fragment per `movedPages` entry.
 `regions/switching-regions` is not part of the merge — it moves to `account/change-your-region`.
 
-### D2 — Four code-vs-docs defects *(settled)*
+### D2 — Four code-vs-docs defects
 
-**Answer: file a terse issue in `onetimesecret/onetimesecret`, labelled `documentation`.**
+**Settled — answer:** file a terse issue in `onetimesecret/onetimesecret`, labelled `documentation`.
 
 Filed as [onetimesecret/onetimesecret#3993](https://github.com/onetimesecret/onetimesecret/issues/3993).
 The defects are code-side, so they leave the docs plan and become app-repo work. All four were
@@ -532,9 +545,9 @@ supported strategy, and `features/custom-domains` carries the same caveat. The D
 rather than a fix — `operate/queues-and-dlq` documents the discard as shipped behaviour, since silently
 dropping a secret link is exactly the kind of thing an operator must be told before they debug it.
 
-### D3 — Billing catalog *(settled)*
+### D3 — Billing catalog
 
-**Answer: the product `billing.yaml` is kept separate. Ask for it when needed.**
+**Settled — answer:** the product `billing.yaml` is kept separate. Ask for it when needed.
 
 So the plan matrix **cannot** be generated, and stays hand-maintained with a named owner; the billing
 catalog is explicitly out of the generator's scope. Applied under *Plans & billing* and *The generated
@@ -544,9 +557,9 @@ catalog before `billing/index` ships. One correction to the audit's framing — 
 what buyers are sold. The published "Member Invites / Up to 50" claim is therefore **unverified**, not
 demonstrated wrong, and it does not belong in Finding 1's table of factual errors.
 
-### D4 — The `/audit-events` rename *(settled)*
+### D4 — The `/audit-events` rename
 
-**Answer: ignore. The previous path was not shipped in a meaningful way, and only for a week.**
+**Settled — answer:** ignore. The previous path was not shipped in a meaningful way, and only for a week.
 
 No deprecation notice, no migration note, no breaking-change entry. Applied: the docs document
 `/secret-activity` only (`apps/api/organizations/routes.txt:20`). `CHANGELOG.rst:57` still names the old
@@ -557,9 +570,9 @@ still fixed in Phase 1. The terminology question ADR-021 was raised for — Secr
 Events vs the operator audit log — is not dropped either; it is answered by `start/glossary`, which is
 where a reader hits it.
 
-### D5 — Translation policy *(settled)*
+### D5 — Translation policy
 
-**Answer: focus on the primary language. Translation is a future initiative, after the dust settles.**
+**Settled — answer:** focus on the primary language. Translation is a future initiative, after the dust settles.
 
 This supersedes the tiered policy the audit proposed. Applied in full under *Translation*: no new
 obligations are created, today's 976 is frozen rather than grown, existing locale files stay and keep
@@ -567,9 +580,9 @@ serving, and no phase blocks on a translation decision. The `translate` frontmat
 from the Phase 2 schema work — `audience` already partitions the tree the way the future initiative
 would select on it. The audit's "63 of 115 pages" framing is moot: it is now 114 of 114.
 
-### D6 — Stub locales *(settled)*
+### D6 — Stub locales
 
-**Answer: ignore; see D5.**
+**Settled — answer:** ignore; see D5.
 
 The nine stub directories stay as they are and are revisited with the translation initiative. Applied
 under *Stub locales*, with the accepted cost stated (they remain indexed) and the cheap mitigation named
@@ -578,9 +591,9 @@ in case it stops being acceptable. **Count correction: nine, not ten.** The audi
 `ca_ES`, `cs`, `el_GR`, `he`, `hu`, `ru`, `sl_SI`, `vi` — out of 26 content directories, 17 of which
 have i18n bundles.
 
-### D7 — Generator ownership *(settled)*
+### D7 — Generator ownership
 
-**Answer: stub for now.**
+**Settled — answer:** stub for now.
 
 The generator moves into this repo and reads a vendored snapshot of `.env.reference` and
 `config.defaults.yaml`; app-repo stages 1–3 leave the critical path. Applied under *The generated
@@ -590,9 +603,9 @@ snapshot is a copy, and the Phase 5 drift gate — snapshot versus upstream, fai
 is what keeps that copy from becoming the next `configuration.md`. The refresh still needs a name
 against it before Phase 4 exits.
 
-### D8 — Removed and inert variables *(settled)*
+### D8 — Removed and inert variables
 
-**Answer: focus on current content. The project is still pre-1.0.**
+**Settled — answer:** focus on current content. The project is still pre-1.0.
 
 `reference/deprecated-and-removed` is cut; Reference drops to 12 pages and the tree to 114. Applied
 under §6 and Phase 1. The two jobs that page carried are rehomed rather than lost: the ~19 unsupported
@@ -604,9 +617,9 @@ still moving.
 
 ---
 
-### D9 — Who owns the end-user task layer? *(open)*
+### D9 — Who owns the end-user task layer?
 
-**Answer: important — work carefully. The largest single scope swing in the plan.**
+**Open — answer as given:** important — work carefully. The largest single scope swing in the plan.
 
 Still open, and it should be. Below is what the plan does in the meantime.
 

--- a/docs/planning/documentation-audit-2026-08.md
+++ b/docs/planning/documentation-audit-2026-08.md
@@ -54,7 +54,7 @@ command follows it. Each of these was verified against source this session:
 | `:colonels:` auto-promotion (`getting-started.md:93`) | removed from the product | new self-hoster ends up with **no admin account** |
 | "no manual step needed" for password migration (`upgrading-v0-24.md:244`) | `bin/ots customers sync-auth-accounts --run` is required | **every pre-existing user locked out** after upgrade |
 | nginx snippet uses `$proxy_add_x_forwarded_for` (`installation.md:244,253`) | appends rather than overwrites | resolved client IPs become spoofable |
-| three removed `UI_HOMEPAGE_*` vars still published as settable | removed | under the default `DEPRECATED_CONFIG_MODE=strict` a removed key **refuses boot** |
+| two removed `UI_HOMEPAGE_*` vars still published as settable | `UI_HOMEPAGE_TRUSTED_PROXY_DEPTH` and `UI_HOMEPAGE_TRUSTED_IP_HEADER` are removed (`config.rb:198-215` `DEPRECATIONS`); the third the docs list, `UI_HOMEPAGE_DEFAULT_MODE`, never existed in the app | under the default `DEPRECATED_CONFIG_MODE=strict` a removed key **refuses boot** |
 | `team/audit-log.md` says "Status: Planned" | shipped in 0.26.0 and since renamed | advertises an unshipped feature that shipped |
 
 Underneath: `configuration.md` is 636 lines of which **596 are one unbroken YAML fence** with no
@@ -76,9 +76,19 @@ links only the unresolvable parent, leaving all five unreachable from navigation
 ## Finding 2 — 183 features have no page at all
 
 Zero-hit greps across the entire `en/` tree: `TXT` · `passkey` · `DLQ` · `sqlite` · `password reset` ·
-`suppress` · `catalog` · `429` · `Retry-After` · `TRUSTED_PROXY` · `HEALTH_TRUSTED_CIDR` ·
-`STANDALONE_ENTITLEMENTS`. `BRAND` returns two hits, both a URL constant — so the entire
-17-variable branding subsystem plus brand packs is absent.
+`suppress` · `catalog` · `429` · `Retry-After` · `HEALTH_TRUSTED_CIDR` · `STANDALONE_ENTITLEMENTS`.
+`BRAND` returns two hits, both a URL constant — so the entire 17-variable branding subsystem plus brand
+packs is absent.
+
+`TRUSTED_PROXY` was on that list and has been removed from it, but not for the reason Appendix A
+implies, so both halves are worth stating precisely. The trusted-proxy *toggle* is genuinely reachable —
+the Configuration Generator offers it (`presets.ts:175,182`, `trusted_proxy_enabled` →
+`site.network.trusted_proxy.enabled`), which is what Appendix A caught. The trusted-proxy *environment
+variables* are still undocumented: `TRUSTED_PROXY_ENABLED`, `_MODE`, `_HEADER` and `_CIDRS` have no
+occurrence anywhere in `src/`. The one uppercase `TRUSTED_PROXY` hit in the published tree is
+`UI_HOMEPAGE_TRUSTED_PROXY_DEPTH` at `environment-variables.md:330` — a **removed** variable. So the
+grep was wrong on a technicality that makes the underlying finding worse rather than better, and
+"invalidated outright" overstates it in the opposite direction.
 
 The `TXT` result is the most expensive single gap on the site: the product UI presents the
 `_onetime-challenge-*` TXT ownership record **first**, verification cannot complete without it, and
@@ -531,7 +541,11 @@ cheap half of what the SEO argument was protecting, and it costs one fragment pe
 
 Filed as [onetimesecret/onetimesecret#3993](https://github.com/onetimesecret/onetimesecret/issues/3993).
 The defects are code-side, so they leave the docs plan and become app-repo work. All four were
-re-verified against source before filing:
+re-verified against source before filing — which also closes four of the six items
+[`…-self-analysis.md`](./documentation-audit-2026-08-self-analysis.md) Appendix C listed as unverified
+and load-bearing. That verification changed one of them: the DLQ discard is **deliberate**, not silent
+in the sense of accidental, and the audit's original wording overclaimed it in exactly the direction
+that analysis warned about.
 
 | Defect | Evidence | Nature |
 |---|---|---|

--- a/docs/planning/documentation-audit-2026-08.md
+++ b/docs/planning/documentation-audit-2026-08.md
@@ -14,6 +14,11 @@ adversarial verifier tasked with *refuting* every claimed gap and a completeness
 finding what the surveys missed. Both adversarial passes landed hits; their corrections are applied
 below and recorded in Appendix A rather than quietly dropped.
 
+**Status — revised 2026-08-04.** The nine decisions this audit raised have been answered. Eight are
+settled; their consequences are applied throughout the plan below and the reasoning is recorded in
+[Decisions](#decisions). One — who owns the end-user task layer — remains open and gates five pages in
+Phase 2; an interim posture is defined so nothing else waits on it.
+
 ---
 
 ## Headline numbers
@@ -114,7 +119,7 @@ passphrase, using the receipt, or burning a link — the product's core action.
   under Team Plus by fiat.
 - Repricing rewrites navigation and invalidates every deep link.
 
-Meanwhile seven top-level slots go to Regions, six of which are one 43–47 line template; the whole REST
+Meanwhile seven top-level slots go to Regions, five of which are one 43–47 line template; the whole REST
 API is a 30-line redirect notice carrying the same nav weight as all of Self-Hosting; and 378 lines of
 SDK examples sit in a one-item group called "Resources".
 
@@ -173,7 +178,7 @@ marketing site. Its current paid CTA points at `pricing/index.md`, which is an o
 | | Page | Covers |
 |---|---|---|
 |`MRG`|`start/index`|absorbs `docs-overview` + `introduction/index` + `introduction/guides`|
-|`NEW`|`start/send-your-first-secret`|the product's core action, end to end|
+|`NEW`|`start/send-your-first-secret` **†**|the product's core action, end to end — gated on [D9](#d9--who-owns-the-end-user-task-layer-open)|
 |`MRG`|`start/run-your-own-instance`|absorbs `self-hosting/getting-started`|
 |`MOV`|`start/hosted-or-self-hosted`|from `self-hosting/self-hosting-vs-hosted`|
 |`NEW`|`start/glossary`|receipt vs private link vs metadata; passphrase vs password; organization vs workspace vs team; colonel vs admin vs staff; entitlement vs permission vs capability; Secret Activity vs Security Events; canonical vs custom domain|
@@ -183,7 +188,12 @@ inside long pages, reachable only by already knowing which page hides them.
 
 #### 3. Using Onetime Secret · 30 pages
 
-**Sharing secrets** (7) — `UPD share/index` (rewritten as a procedure) · `NEW share/your-receipt`
+Pages marked **†** are gated on [D9](#d9--who-owns-the-end-user-task-layer-open). Eleven of the twelve
+contested end-user pages are in this section — the twelfth, `start/send-your-first-secret`, is in *Start
+here* and is also gated — and the seven unmarked ones proceed regardless of how D9 lands. The rule that
+separates them is stated after *Your account*.
+
+**Sharing secrets** (7) — `UPD share/index` **†** (rewritten as a procedure) · `NEW share/your-receipt`
 (private link, burn, one-time reveal of a generated password, `GENERATED_VALUE_DISPLAY_TTL`) ·
 `NEW share/what-recipients-see` · `NEW share/when-a-link-doesnt-work` (the unified "no longer
 available" response and the deliberate absence of an existence oracle — highest-volume support
@@ -192,13 +202,25 @@ deflection page on the site) · `SPL share/receiving-secrets` · `MOV share/use-
 
 **Your account** (8) — `NEW account/signing-in` (incl. password reset, absent today) ·
 `NEW account/two-factor-and-passkeys` (TOTP, recovery codes, WebAuthn — `passkey` has zero hits) ·
-`NEW account/sessions-and-identities` · `NEW account/dashboard-and-recent-secrets` ·
-`NEW account/change-your-email` · `NEW account/close-your-account` · `NEW account/preferences` ·
+`NEW account/sessions-and-identities` **†** · `NEW account/dashboard-and-recent-secrets` **†** ·
+`NEW account/change-your-email` · `NEW account/close-your-account` · `NEW account/preferences` **†** ·
 `MOV account/change-your-region`
 
 > Email change and account deletion are both shipped, both irreversible, and both absent. "How do I
 > delete my account and my data" is the question a privacy-first product is most expected to answer,
 > and the site currently cannot.
+
+**The rule.** In-app guidance can only reach a signed-in user inside a working flow. Everything a
+recipient without an account, a user who cannot sign in, or an evaluator who has not signed up needs
+must live in the docs, because the product has no way to show it to them. Applying that rule splits the
+twelve contested pages cleanly: `share/what-recipients-see` and `share/when-a-link-doesnt-work` serve
+recipients who have no account; `account/signing-in` (password reset) and
+`account/two-factor-and-passkeys` (recovery codes, MFA lockout) serve users who are locked out by
+definition; `account/change-your-email` and `account/close-your-account` are irreversible actions people
+research *before* performing; and `share/your-receipt` documents behaviour — burn, one-time reveal,
+`GENERATED_VALUE_DISPLAY_TTL` — that no screen states. None of those seven is a duplicate of in-app
+guidance under any answer to D9. The five marked **†** are in-flow UI walkthroughs and are the only
+genuine duplicate risk.
 
 **Organizations & members** (6) — `MRG organizations/index` (absorbs `team/shared-dashboard`) ·
 `NEW organizations/roles-and-permissions` (**the plan ∩ role rule** — why a paid feature is still
@@ -214,6 +236,11 @@ ownership step**) · `UPD custom-domains/dns-validation` · `MOV custom-domains/
 
 **Plans & billing** (2) — `MRG billing/index` (de-orphans `pricing/index`, absorbs `compare-plans`) ·
 `NEW billing/managing-your-subscription`
+
+> Per [D3](#d3--billing-catalog-settled), the plan matrix is **hand-maintained with a named owner** and
+> is explicitly out of the generated reference's scope. Its source of truth is the production
+> `etc/billing.yaml`, which lives outside both repos and is requested when a docs task needs it.
+> `etc/examples/billing.example.yaml` is an example file and cannot arbitrate what buyers are sold.
 
 #### 4. Self-hosting · 43 pages
 
@@ -234,6 +261,13 @@ pages) · `SPL install/docker` · `SPL install/linux` · `SPL install/run-as-a-s
 `NEW features/multi-region` · `NEW features/billing-and-entitlements` · plus two **operator-only**
 surfaces with no hosted counterpart, which fell out of the first draft precisely because it was
 organised as an audience mirror: `NEW features/feedback-channel` · `NEW features/broadcast-banner`
+
+> `features/caddy-on-demand-tls` must not be written as a working strategy. Per
+> [D2](#d2--four-code-vs-docs-defects-settled), `caddy_on_demand` currently issues no certificate at all;
+> the page documents the two strategies that work (`passthrough`, `approximated`) and states plainly
+> that the third does not, until the app-repo issue closes. `features/custom-domains` carries the same
+> caveat where it lists strategy choices, and `operate/queues-and-dlq` documents the DLQ consumer's
+> deliberate discard of non-auth mail as shipped behaviour rather than treating it as a defect.
 
 **Operate** (10) — `NEW operate/background-jobs` · `NEW operate/queues-and-dlq` ·
 `NEW operate/scheduled-and-maintenance-jobs` · `NEW operate/datastore` (Valkey/Redis is the **system of
@@ -260,15 +294,23 @@ CHANGELOG's bolded Action Required migration**, `bin/ots migrate --run 20260703_
 > This is the most-linked developer material on any docs site. Burying it under a reference spine
 > nobody browses inherits the wrong navigation behaviour.
 
-#### 6. Reference · 13 pages — generated, English-only
+#### 6. Reference · 12 pages — generated
 `NEW reference/index` (how to read it; **which page owns a default**) ·
-`SPL reference/environment-variables` · `NEW reference/deprecated-and-removed` (what makes
-`DEPRECATED_CONFIG_MODE=strict` survivable) · `NEW reference/cli` (`bin/ots`) ·
+`SPL reference/environment-variables` · `NEW reference/cli` (`bin/ots`) ·
 `NEW reference/scheduled-jobs` · `NEW reference/health-endpoints` · then *Configuration keys* (7),
 **titled by subject rather than by YAML stanza**: `configuration-files-and-precedence` ·
 `generator` (moved, given a content wrapper so it stops being an invisible sidebar entry) ·
 `site-and-interface` · `features-and-branding` · `datastore-and-queues` · `email-and-delivery` ·
 `auth-logging-and-billing-files`
+
+> `reference/deprecated-and-removed` is **cut** per [D8](#d8--removed-and-inert-variables-settled): the
+> project is pre-1.0 and the reference documents what the current version reads, nothing else. The two
+> jobs that page was carrying still need homes, and both are cheaper than a graveyard inventory. The ~19
+> unsupported variables the site publishes today are **deleted outright** in Phase 1, not relocated —
+> a variable that is gone should leave no trace to copy. And surviving `DEPRECATED_CONFIG_MODE=strict`
+> becomes a troubleshooting path (`troubleshoot/boot-failures`: boot refused on an unrecognised key,
+> here is how to find and remove it) plus the precedence section of `configure/index`, which already
+> owns the setting. Neither requires publishing an inventory of what older versions read.
 
 #### 7. Trust & security · 8 pages
 `UPD security/index` · `NEW security/how-one-time-access-works` · `NEW security/passphrase-protection` ·
@@ -276,13 +318,27 @@ CHANGELOG's bolded Action Required migration**, `bin/ots migrate --run 20260703_
 `MOV security/best-practices` · `MRG security/our-principles` (the four principles pages) ·
 `security/vulnerability-disclosure`
 
+> The region merge is settled by [D1](#d1--per-region-pages-settled) in favour of reader experience over
+> search ranking. One consequence is worth building for rather than accepting: give
+> `where-your-data-lives` a stable per-region anchor (`#european-union`, `#canada`, …) and point each
+> retired URL at its anchor rather than at the page top. A compliance questionnaire that cites
+> `/regions/european-union` then still lands on the EU facts, and the merged page has to carry every
+> per-region fact the five templates carried — jurisdiction, data location, operating entity — or the
+> merge trades away something real. `regions/switching-regions` is not part of the merge; it moves to
+> `account/change-your-region`, where a reader looking for the procedure will be.
+
 #### 8. Translations & contributing · 10 pages
 Renamed from "Contribute", which today holds nine pages of translation guidance and no contributor
 documentation at all. `NEW contribute/developer-on-ramp` (`bin/dev`, `bin/setup --test`, the
 containerized test lanes, the 32 ADRs) plus the nine existing translation pages moved, including the
 five currently orphaned under `translations/universal/`.
 
-**Totals: 61 pages → 115. ~63 new, ~20 moved, ~14 merged away, 1 deleted.**
+> This section is guidance *for* translators. It is unaffected by [D5](#d5--translation-policy-settled)
+> deferring translation *of* the site: the contributors it serves are the ones the future initiative
+> will depend on, so its pages stay in the tree and get fixed in Phase 1.
+
+**Totals: 61 pages → 114. ~62 new, ~20 moved, ~14 merged away, 1 deleted.** Of the 62 new pages, five are
+held pending [D9](#d9--who-owns-the-end-user-task-layer-open).
 
 ---
 
@@ -290,15 +346,30 @@ five currently orphaned under `translations/universal/`.
 
 **Phase 1 — stop the bleeding (1–2 weeks).** Corrections in place. No sidebar change, no new
 translation keys, no redirects, so it ships independently of every other decision here. Fix the ~25
-wrong statements in Finding 1; add the missing TXT step to `setup-guide.md`; publish
+wrong statements in Finding 1; **delete** the ~19 no-longer-supported variables the site publishes as
+settable rather than relocating them (per D8); add the missing TXT step to `setup-guide.md`; publish
 `configure/secrets-and-keys` and `share/when-a-link-doesnt-work` early; rename
 `translations/universal/_index.md` → `index.md` to fix the live 404; delete
-`translations/language-notes.md` (an 11-line unfinished `[placeholder]` table).
-*Start the app-repo reference generator now* — it is the critical path for Phase 4.
+`translations/language-notes.md` (an 11-line unfinished `[placeholder]` table) — **all 26 copies**, one
+per locale directory, since every copy is the same unfilled template. That last deletion drops the nine
+stub locales from three files to two, which is consistent with [D6](#d6--stub-locales-settled): it
+neither completes nor removes them.
+
+Two additions from the decisions: the four code-vs-docs defects are filed as
+[onetimesecret#3993](https://github.com/onetimesecret/onetimesecret/issues/3993) (D2) — done, and done
+first, because three of the four determine what Phase 3 is allowed to claim; and **stand up
+the stub reference generator in this repo** (D7) rather than waiting on app-repo commits — see
+*The generated reference* below. The original instruction here was "start the app-repo generator now,
+it is the critical path for Phase 4"; D7 removes that dependency from the critical path instead of
+resolving it.
 
 **Phase 2 — reshape and build the end-user task layer (5–7 weeks).** 14 top-level entries become 8;
 tiers leave navigation; orphans are absorbed; the end-user surface gets its first real how-tos.
-Prerequisite: extend `docsSchema()` with `plan`, `audience`, `pageType`, `translate`, `sourceOfTruth`.
+Prerequisite: extend `docsSchema()` with `plan`, `audience`, `pageType`, `sourceOfTruth`. (`translate`
+is dropped — see D5; `audience` already partitions the tree the way a future translation initiative
+would need to select on it, so a second field would only duplicate that partition and start drifting
+from it.) Seven of the twelve end-user pages proceed unconditionally; the five marked **†** wait on D9,
+and if the answer arrives late they are the phase's tail, not its trunk.
 
 **Phase 3 — the operator install and configure tree (6–8 weeks).** Split `installation.md` (470 lines,
 six unrelated jobs) into task pages; write the operator feature pages. Highest per-page research cost
@@ -306,12 +377,18 @@ six unrelated jobs) into task pages; write the operator feature pages. Highest p
 
 **Phase 4 — the generated reference and the Day-2 layer (7–9 weeks, ~3 engineering).** Stand up the
 pipeline, retire `configuration.md` and `environment-variables.md`, complete Operate and Troubleshoot.
-Ship `reference/environment-variables` and `reference/deprecated-and-removed` first — highest defect
-density, simplest generators, straight replacements.
+Ship `reference/environment-variables` first — highest defect density, simplest generator, a straight
+replacement. It now runs off the vendored snapshot rather than a live app-repo feed (D7), which lowers
+this phase's engineering estimate and removes its external blocker, at the cost of a refresh step that
+Phase 5 has to own.
 
 **Phase 5 — drift prevention (3–4 weeks).** Every defect in this audit went unnoticed because nothing
 checks for it. Add `check:orphans`, `check:nav`, a frontmatter linter, and a reference-drift CI gate.
 Today's only QA scripts are link checkers and a vitest suite covering the config generator alone.
+Under D7 the drift gate has one more job: it compares the **vendored snapshot** against upstream
+`.env.reference` and `config.defaults.yaml` and fails when they diverge. That is the mechanism that
+keeps a stubbed generator honest — without it the snapshot silently becomes the same hand-maintained
+copy this plan exists to delete, and the reshape ends up cosmetic.
 
 ---
 
@@ -333,16 +410,47 @@ precedent (per-locale fan-out for the `principles/trust` merge; many-to-one coll
 `/rest-api/v1|v2/*` tree). Generate from a `movedPages` array, don't hand-write. Note the existing
 top-level `"/pricing"` entry sends the bare path off-site while `/en/pricing/` is an unnavigable
 orphan, and `"/getting-started": "/en/introduction"` will chain into a page that no longer exists.
+The region family (D1) is the one case that needs **anchor targets rather than page targets** —
+`/regions/european-union` → `/security/where-your-data-lives#european-union`, and likewise for the other
+four — so the `movedPages` entries carry an optional fragment.
 
-**Translation.** Measured: no locale is at parity (best 41/61; most 36–40), and ten further directories
-hold 3 files each with no i18n bundle and no sidebar entry. Proposed policy — translate the 40
-end-user pages (Home, Start here, Using Onetime Secret, Trust & security); make Self-hosting, Reference
-and Translations English-only by construction, which is already the de facto state.
-**40 × 16 = 640 obligations against today's 976 — a 34% reduction in standing liability while English
-coverage nearly doubles.** Mechanism: a `translate: z.boolean().default(true)` frontmatter field plus a
-check in `bin/translation-pluribus-util`. Do **not** copy the `configuration-generator.astro` escape
-hatch — it is English-only but also drops out of Pagefind, prev/next and the content collection, which
-is exactly why that sidebar entry currently points at something invisible.
+**Translation.** Measured: no locale is at parity (best 41/61; most 36–40), and nine further directories
+hold 3 files each with no i18n bundle and no sidebar entry. The audit proposed a tiered policy —
+translate the end-user surface, make the operator and reference trees English-only by construction.
+[D5](#d5--translation-policy-settled) replaces that with something simpler and more honest about
+sequencing: **English is the only language this plan ships in, and translation is a separate initiative
+scoped after the restructure settles.**
+
+The practical difference is larger than it sounds. A tiered policy is a standing obligation that has to
+be enforced on every page as it is written, and it has to be negotiated with 16 locale maintainers
+before Phase 2 can start. Deferral is neither. Concretely:
+
+- **No new obligations are created.** Today's 976 (61 published pages × 16 locales with i18n bundles) is
+  frozen, not grown. Existing locale files stay exactly where they are and keep serving; nothing is
+  deleted and no locale is told its content is being dropped.
+- **Nothing in Phases 1–5 blocks on a translation decision.** English pages ship as they are written.
+  Locales fall back to the English label for any sidebar key their bundle lacks —
+  `buildTranslations()` already includes a locale only if that bundle has the key, and the file's own
+  comment says this is deliberate.
+- **The future initiative gets a cleaner input than it would have now.** Once the tree stops moving, its
+  scope is a selection over `audience`, not a hand-curated list: the end-user surface is Home, Start
+  here, Using Onetime Secret and Trust & security — 44 pages in the proposed tree, or 39 if D9 goes
+  against the five gated walkthroughs. Deciding tiering *now* would mean tiering a tree that Phases 2–4
+  are still rewriting.
+
+Do **not** copy the `configuration-generator.astro` escape hatch for English-only pages — it is
+English-only but also drops out of Pagefind, prev/next and the content collection, which is exactly why
+that sidebar entry currently points at something invisible. English-only is a content decision, not a
+rendering one.
+
+**Stub locales.** The nine 3-file directories (`ar`, `ca_ES`, `cs`, `el_GR`, `he`, `hu`, `ru`, `sl_SI`,
+`vi`) are left in place per [D6](#d6--stub-locales-settled) and revisited with the translation
+initiative. They stay indexed and reachable, which is a knowingly accepted cost: each holds only
+translation-contributor guidance, so a reader who lands there finds a real page, not a broken product
+doc. If that changes — if the restructure ever routes product content into them — the cheap fix is a
+`noindex` on the nine, not a completion project. Note the app ships 30 locales to the docs site's 17
+with i18n bundles (26 content directories), so "which locales exist" is itself unsettled and worth
+resolving *with* the initiative rather than ahead of it.
 
 **The generated reference.** Sources are already rich enough: `.env.reference` carries 353 variables
 across 52 banner sections with per-variable prose, defaults, constraints, `[derived]`/`[independent]`/
@@ -352,6 +460,34 @@ rather than inventing a second one** — `src/components/config-generator/schema
 Schemas generated in the app repo by `pnpm run schemas:json:generate`, with env mappings curated in
 `presets.ts`. The generator emits to the docs repo; CI fails on drift.
 
+[D7](#d7--generator-ownership-settled) stubs the app-repo half of that pipeline, so the shape changes:
+the generator lives **in this repo from the start** and reads a **vendored snapshot** of
+`.env.reference` and `config.defaults.yaml` — the same vendoring pattern
+`src/components/config-generator/schemas/` already uses, which is why this is a stub and not a new
+invention. The input contract is fixed now; swapping the snapshot for a live app-repo feed later is a
+change of source, not a rewrite of the generator or of any page it emits.
+
+What this buys and what it costs, stated plainly, because the audit called generator ownership the
+plan's highest-risk dependency and stubbing it does not make that risk disappear:
+
+- **Bought:** Phase 4 stops depending on commits to a repo with no named owner and no backlog slot. The
+  reference pages are generated-shaped from day one, so they cannot quietly regress into the
+  hand-written copies that produced Finding 1.
+- **Cost:** a snapshot is a copy, and copies drift. The Phase 5 drift gate — snapshot versus upstream,
+  failing CI on divergence — is what converts that copy into a tracked one. **Without the gate, D7
+  recreates the exact defect this plan exists to fix, one level down.** The gate is not optional
+  polish; it is the other half of the decision.
+- **Still unowned:** app-repo stages 1–3. They are no longer on the critical path, but the snapshot
+  refresh needs a name against it before Phase 4 exits. Revisit there.
+
+**Out of scope for the generator:** the billing catalog. Per D3 the production `etc/billing.yaml` lives
+outside both repos, so the plan matrix cannot be generated and stays hand-maintained with a named owner.
+Before Phase 2 publishes `billing/index`, verify `compare-plans.md:19` ("Member Invites" ✅ for Identity
+Plus) and `:24` ("Members per organization — Up to 50") against the production catalog and request it
+for that check. The in-repo `etc/examples/billing.example.yaml` gives `identity_plus_v1` no
+`manage_members` entitlement, `total_members_per_org: 1`, and comments the team tier out entirely — but
+it is an *example*, so it establishes that the published claim is unverified, not that it is wrong.
+
 Worth noting: `docs/templates/README.md` already mandates a four-type content model (Concept guide /
 How-to / Reference / Architecture note) with a `Source of truth:` field and the rule "GENERATE OR
 TABLE-DRIVE reference where possible… rather than hand-maintaining a parallel copy that will drift."
@@ -360,49 +496,167 @@ repo already documents.**
 
 ---
 
-## Decisions needed
+## Decisions
 
-1. **Per-region pages: merge or keep?** Merging five 43–47 line templates into one comparison page
-   kills ~80 translation obligations, but those URLs plausibly carry SEO value ("onetimesecret EU data
-   residency") and get cited in compliance questionnaires. Redirects preserve the URLs, but a redirect
-   is not a landing page. Marketing/SEO call, not a docs call.
-2. **Caddy on-demand TLS: document the limitation, fix it, or remove the option?**
-   `caddy_on_demand_strategy.rb:61` returns `is_resolving: nil`, so `ready?` is never true and the ask
-   endpoint 403s every domain — no certificate is ever issued. It is currently listed as a supported
-   strategy with no warning. Same question for three other flagged defects: the DLQ consumer silently
-   discarding secret links and expiration warnings; `JOBS_SCHEDULER_ENABLED` / `JOBS_FALLBACK_SYNC`
-   being read by no code while `docker-compose.full.yml` tells operators to set them; and
-   `features.domains.strict_strategy` existing in code but in no config file.
-3. **Which billing catalog is authoritative?** `compare-plans.md` promises Identity Plus buyers "Member
-   Invites, up to 50". The only catalog in the repo gives `identity_plus_v1` no `manage_members`
-   entitlement and `total_members_per_org: 1`, with the team tier commented out. Production
-   `etc/billing.yaml` is not in the repo. This determines whether the plan matrix can be generated at
-   all, or must stay hand-maintained with a named owner.
-4. **Is `/audit-events` → `/secret-activity` a supported breaking change?** `CHANGELOG.rst` documents
-   the old path for 0.26.0; routes now serve the new one. Anyone who integrated is broken and nothing
-   public says so. Related: ADR-021, which settles the terminology, is still `status: proposed`.
-5. **Should the operator and reference trees be English-only by policy?** 63 of 115 pages. The
-   empirical case is strong, but it formally tells a German-speaking self-hoster their operator docs
-   will not be translated. Consult the 16 locale maintainers. Middle position: translate the
-   Self-hosting overview and the two decision guides (~5 pages), leave the rest English.
-6. **What happens to the ten stub locales?** `ar`, `ca_ES`, `cs`, `el_GR`, `he`, `hu`, `ru`, `sl_SI`,
-   `vi` and one sibling hold 3 files each, have no i18n bundle, appear in no sidebar map — and are
-   indexed and reachable. Complete or remove? Note the app ships 30 locales to the docs site's 17.
-7. **Who owns the app-repo generator?** Stages 1–3 are commits to `onetimesecret`, not to this repo,
-   and they gate Phase 4. Without a named owner and a backlog slot, the realistic outcome is Phase 4
-   ships hand-written reference pages that drift exactly as the current two have — making the reshape
-   cosmetic. **Highest-risk dependency in the plan.**
-8. **Should removed and inert variables be published at all?** The deprecated/removed/inert reference
-   page is what makes `DEPRECATED_CONFIG_MODE=strict` survivable, and it prevents the
-   silent-misconfiguration class — setting a variable that looks right and does nothing. Against: it
-   publishes a precise inventory of what older versions read, and names variables that exist in the
-   codebase but are not wired up. Low risk and high operational value in our assessment, but it is a
-   security-posture call for whoever owns `SECURITY.md`, not a docs call.
-9. **Does the docs site own the end-user "send a secret" layer, or does the product?** Twelve of the
-   highest-traffic proposed pages document a UI that arguably should be self-explanatory. The content
-   demonstrably does not exist anywhere today, but if in-app guidance is planned, these pages should be
-   scoped as its durable linkable reference rather than a duplicate. Settle before Phase 2 — it
-   determines ~12 pages and the entire Tier 1 translation set.
+Nine decisions were raised by the audit. Eight are settled and their consequences are applied
+throughout the plan above; one is open. Each entry records the answer as given, then what changed.
+
+### D1 — Per-region pages *(settled)*
+
+**Answer: prioritise developer experience; deprioritise SEO.**
+
+The five 43–47 line templates merge into `security/where-your-data-lives`. Applied: the merge is now
+stated as settled rather than conditional; the merged page must carry every per-region fact the
+templates carried; and the retired URLs redirect to **per-region anchors**, not to the page top, so a
+compliance questionnaire citing `/regions/european-union` still lands on the EU facts. This is the
+cheap half of what the SEO argument was protecting, and it costs one fragment per `movedPages` entry.
+`regions/switching-regions` is not part of the merge — it moves to `account/change-your-region`.
+
+### D2 — Four code-vs-docs defects *(settled)*
+
+**Answer: file a terse issue in `onetimesecret/onetimesecret`, labelled `documentation`.**
+
+Filed as [onetimesecret/onetimesecret#3993](https://github.com/onetimesecret/onetimesecret/issues/3993).
+The defects are code-side, so they leave the docs plan and become app-repo work. All four were
+re-verified against source before filing:
+
+| Defect | Evidence | Nature |
+|---|---|---|
+| `caddy_on_demand` issues no certificate | `caddy_on_demand_strategy.rb:61` returns `is_resolving: nil`; `verify_domain.rb:323` skips the write when nil, so `resolving` — written nowhere else — never becomes `true`, `ready?` never returns true, and `apps/internal/acme` 403s every domain | real defect |
+| DLQ consumer discards secret links and expiration warnings | `dlq_email_consumer_job.rb:151-155` nacks any non-`AUTH_TEMPLATES` message | **intended**, per the class comment — but invisible to operators |
+| `JOBS_SCHEDULER_ENABLED` / `JOBS_FALLBACK_SYNC` are inert | both map to config keys (`config.defaults.yaml:1035,1051`) that no production code reads, while `docker/README.md:90` and `docker-compose.full.yml:253` instruct operators to set them | doc-vs-code contradiction |
+| `features.domains.strict_strategy` is unreachable by config | read at `strategy.rb:39`, present in no file under `etc/`, `.env.reference` or `docker/` | code-only knob |
+
+Applied: `features/caddy-on-demand-tls` is written as *not currently functional* rather than as a
+supported strategy, and `features/custom-domains` carries the same caveat. The DLQ row is a docs job
+rather than a fix — `operate/queues-and-dlq` documents the discard as shipped behaviour, since silently
+dropping a secret link is exactly the kind of thing an operator must be told before they debug it.
+
+### D3 — Billing catalog *(settled)*
+
+**Answer: the product `billing.yaml` is kept separate. Ask for it when needed.**
+
+So the plan matrix **cannot** be generated, and stays hand-maintained with a named owner; the billing
+catalog is explicitly out of the generator's scope. Applied under *Plans & billing* and *The generated
+reference*, with a Phase 2 precondition: verify `compare-plans.md:19` and `:24` against the production
+catalog before `billing/index` ships. One correction to the audit's framing — it called
+`etc/examples/billing.example.yaml` "the only catalog in the repo", but an example file cannot arbitrate
+what buyers are sold. The published "Member Invites / Up to 50" claim is therefore **unverified**, not
+demonstrated wrong, and it does not belong in Finding 1's table of factual errors.
+
+### D4 — The `/audit-events` rename *(settled)*
+
+**Answer: ignore. The previous path was not shipped in a meaningful way, and only for a week.**
+
+No deprecation notice, no migration note, no breaking-change entry. Applied: the docs document
+`/secret-activity` only (`apps/api/organizations/routes.txt:20`). `CHANGELOG.rst:57` still names the old
+path; it is stale, it is app-repo content, and at one week of exposure it is not worth a correction that
+would advertise a path nobody should now use. Unchanged by this: `team/audit-log.md` still says
+"Status: Planned" for a feature that shipped in 0.26.0, which remains a genuine Finding 1 error and is
+still fixed in Phase 1. The terminology question ADR-021 was raised for — Secret Activity vs Security
+Events vs the operator audit log — is not dropped either; it is answered by `start/glossary`, which is
+where a reader hits it.
+
+### D5 — Translation policy *(settled)*
+
+**Answer: focus on the primary language. Translation is a future initiative, after the dust settles.**
+
+This supersedes the tiered policy the audit proposed. Applied in full under *Translation*: no new
+obligations are created, today's 976 is frozen rather than grown, existing locale files stay and keep
+serving, and no phase blocks on a translation decision. The `translate` frontmatter field is dropped
+from the Phase 2 schema work — `audience` already partitions the tree the way the future initiative
+would select on it. The audit's "63 of 115 pages" framing is moot: it is now 114 of 114.
+
+### D6 — Stub locales *(settled)*
+
+**Answer: ignore; see D5.**
+
+The nine stub directories stay as they are and are revisited with the translation initiative. Applied
+under *Stub locales*, with the accepted cost stated (they remain indexed) and the cheap mitigation named
+in case it stops being acceptable. **Count correction: nine, not ten.** The audit listed nine locales
+"and one sibling"; a directory-by-directory count finds exactly nine holding three files each — `ar`,
+`ca_ES`, `cs`, `el_GR`, `he`, `hu`, `ru`, `sl_SI`, `vi` — out of 26 content directories, 17 of which
+have i18n bundles.
+
+### D7 — Generator ownership *(settled)*
+
+**Answer: stub for now.**
+
+The generator moves into this repo and reads a vendored snapshot of `.env.reference` and
+`config.defaults.yaml`; app-repo stages 1–3 leave the critical path. Applied under *The generated
+reference* and in Phases 1, 4 and 5. The honest reading: this converts the plan's highest-risk
+dependency from *blocking* to *deferred*, which is an improvement, but it does not remove the risk. A
+snapshot is a copy, and the Phase 5 drift gate — snapshot versus upstream, failing CI on divergence —
+is what keeps that copy from becoming the next `configuration.md`. The refresh still needs a name
+against it before Phase 4 exits.
+
+### D8 — Removed and inert variables *(settled)*
+
+**Answer: focus on current content. The project is still pre-1.0.**
+
+`reference/deprecated-and-removed` is cut; Reference drops to 12 pages and the tree to 114. Applied
+under §6 and Phase 1. The two jobs that page carried are rehomed rather than lost: the ~19 unsupported
+variables the site publishes are **deleted** in Phase 1 rather than relocated to a graveyard, and
+surviving `DEPRECATED_CONFIG_MODE=strict` becomes a `troubleshoot/boot-failures` path plus the
+precedence section of `configure/index`. Pre-1.0 also makes the case stronger than "not now": an
+inventory of what removed versions read would need maintaining against a deprecation surface that is
+still moving.
+
+---
+
+### D9 — Who owns the end-user task layer? *(open)*
+
+**Answer: important — work carefully. The largest single scope swing in the plan.**
+
+Still open, and it should be. Below is what the plan does in the meantime.
+
+**What the swing actually is now.** The audit sized this at "~12 pages plus the entire Tier 1
+translation set". D5 removes the second half from the near term — no translation set is being built in
+any phase — but does not delete it: when the translation initiative starts, whether these pages exist
+determines how large its first tier is. So D9 has one effect on Phases 1–5 and one on the initiative
+after them. Applying the reachability rule stated in §3 shrinks the near-term effect further, from
+twelve pages to five:
+
+| | Page | Why |
+|---|---|---|
+|**proceeds**|`share/what-recipients-see`|recipients have no account; the product cannot reach them|
+|**proceeds**|`share/when-a-link-doesnt-work`|same, and it is the highest-volume support-deflection page on the site|
+|**proceeds**|`account/signing-in`|password reset — a user who cannot sign in cannot read in-app guidance|
+|**proceeds**|`account/two-factor-and-passkeys`|recovery codes and MFA lockout, same reason|
+|**proceeds**|`account/change-your-email`|irreversible; researched before it is performed|
+|**proceeds**|`account/close-your-account`|irreversible, and the question a privacy-first product is most expected to answer|
+|**proceeds**|`share/your-receipt`|documents behaviour no screen states — burn, one-time reveal, `GENERATED_VALUE_DISPLAY_TTL`|
+|**† held**|`start/send-your-first-secret`|in-flow walkthrough|
+|**† held**|`share/index`|in-flow walkthrough|
+|**† held**|`account/sessions-and-identities`|in-flow walkthrough|
+|**† held**|`account/dashboard-and-recent-secrets`|in-flow walkthrough|
+|**† held**|`account/preferences`|in-flow walkthrough|
+
+None of the seven duplicates in-app guidance under *any* answer, because in-app guidance cannot reach
+the reader who needs them. The five are the genuine duplicate risk, and they are also the pages that go
+stale fastest, since they describe screens rather than behaviour.
+
+**The options.**
+
+1. **Docs own all twelve.** Fastest to the reader, and the only option that guarantees the content
+   exists. If in-app guidance later ships, five pages become a second surface describing the same
+   screens, and the two drift.
+2. **The product owns the layer; docs carry none of it.** Not actually available for the seven —
+   choosing it means accepting that recipients, locked-out users and evaluators keep getting nothing,
+   which is today's outcome.
+3. **Split by reachability** — docs own what the product cannot reach plus durable behaviour; the
+   product owns in-flow guidance; the five held pages become short reference targets the app deep-links
+   *into* from its empty and error states, rather than walkthroughs that restate screens.
+
+**Recommendation: 3, with a deadline attached.** Build the seven now; hold the five until Phase 2 opens.
+If in-app guidance is not funded with a date by then, build the five as well under option 1 — because
+"this UI should be self-explanatory" is precisely the assumption that produced zero end-user content in
+61 published pages. The failure mode here is not a wrong answer; it is an unowned question staying
+unowned while both sides assume the other has it.
+
+**What would settle it:** a yes/no on whether in-app guidance is scheduled inside the Phase 2 window,
+and if yes, who writes it. That is a product call, not a docs call. **Needed before Phase 2 opens** —
+about five weeks after Phase 1 starts, which is the slack this decision has.
 
 ---
 


### PR DESCRIPTION
## What changed

This revision applies eight settled decisions from the documentation audit and records one open decision (D9) with an interim posture. The plan now includes:

- **Decision framework** (§ Decisions): Eight decisions settled with consequences applied throughout; one open decision (D9: end-user task layer ownership) with a reachability-based split that holds five pages pending a product commitment.
- **Revised scope**: Reference section drops from 13 to 12 pages (D8: `reference/deprecated-and-removed` cut); total tree is now 114 pages instead of 115. Five new pages are held pending D9.
- **Phase 1 corrections**: Delete ~19 unsupported variables outright rather than relocating them (D8); file code-side defects in app-repo (D2); stand up stub reference generator in this repo rather than waiting on app-repo (D7).
- **Phase 2 schema change**: Drop `translate` field; `audience` already partitions the tree for future translation initiative (D5). Seven of twelve end-user pages proceed unconditionally; five marked **†** wait on D9.
- **Phase 4–5 generator work**: Generator reads vendored snapshot of `.env.reference` and `config.defaults.yaml` (D7); Phase 5 drift gate compares snapshot against upstream to prevent silent divergence.
- **Translation deferral** (D5): No new obligations created; existing 976 frozen; translation is a separate initiative after restructure settles. Stub locales (D6) stay in place and are revisited with the initiative.
- **Billing catalog** (D3): Hand-maintained with named owner; explicitly out of generator scope. Production `etc/billing.yaml` is requested when needed.
- **Region merge** (D1): Five per-region pages merge into `security/where-your-data-lives` with per-region anchors so compliance questionnaires citing `/regions/european-union` still land on EU facts.

The audit's nine decisions are now recorded with reasoning and applied consequences. D9 remains open with a recommendation: build the seven reachable pages now; hold the five in-flow walkthroughs until Phase 2 opens, with a deadline for the product to commit to in-app guidance or accept docs ownership.

## Page taxonomy

- [x] N/A — this change introduces no new decision the reader has to make. It documents decisions already made and applies their consequences to the plan.

## Checklist

- [x] Internal links resolve within the current locale — all cross-references to decisions use fragment anchors (`#d1--per-region-pages-settled`, etc.)
- [x] No new pages created; this is a revision of existing planning documents
- [x] Sidebar and translation keys unchanged — no navigation structure modified

https://claude.ai/code/session_017AkufjfexdsyydC7xbdeEg