### PR TITLE
fix(a11y): restore readable ink on active sidebar link and other accent pairs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Check locale configuration
         run: pnpm run check:locales
 
+      - name: Check colour contrast
+        run: pnpm run check:contrast
+
       - name: Test
         run: pnpm test
 

--- a/bin/check-contrast.mjs
+++ b/bin/check-contrast.mjs
@@ -1,0 +1,301 @@
+#!/usr/bin/env node
+//
+// check-contrast.mjs — verify the theme's colour pairs meet WCAG 2.2 AA.
+//
+// Starlight pairs an ink token with a surface token in its own component CSS
+// (`@layer starlight.core`). src/styles/theme-overrides.css restyles some of
+// those surfaces without restating the ink, so a token can drift out from under
+// its partner and produce an unreadable pair that still builds green — the
+// active sidebar link once rendered white-on-near-white at 1.14:1 this way.
+//
+// Every pair below names the rule it mirrors. Token VALUES come from
+// theme-overrides.css at run time (see bin/lib/contrast.mjs), so changing a
+// colour there is what this check measures.
+//
+// Fails (exit 1) listing any pair under its WCAG 2.2 minimum.
+//
+// Usage: pnpm run check:contrast
+import { readFileSync } from "node:fs";
+
+import {
+  AA_MINIMUM,
+  OVERRIDES_CSS,
+  contrastRatio,
+  mixOver,
+  parseColor,
+  parseRules,
+  resolveTokens,
+  round2,
+  toHex,
+} from "./lib/contrast.mjs";
+
+/**
+ * The colour pairs the rendered page actually composes.
+ *
+ * `fg`/`bg` are either a token name, a literal colour, or a
+ * `[token, pct, backdrop?]` tuple meaning
+ * `color-mix(in srgb, <token> <pct>%, transparent)` composited over `backdrop`
+ * — the tint form used throughout the stylesheet. `backdrop` defaults to
+ * --sl-color-bg; the sidebar passes --sl-color-bg-sidebar, which is a
+ * different grey in dark mode (neutral-800 vs the page's neutral-900).
+ *
+ * `kind` picks the WCAG minimum: `text` (4.5:1, SC 1.4.3), `large` (3:1, same
+ * SC) or `non-text` (3:1, SC 1.4.11).
+ */
+const SIDEBAR_BG = "--sl-color-bg-sidebar";
+
+const PAIRS = [
+  // --- Sidebar (theme-overrides.css "--- Sidebar ---") ---------------------
+  {
+    where: ".sidebar a[aria-current=page]",
+    what: "active link label on its accent tint",
+    fg: "--sl-color-accent-high",
+    bg: ["--sl-color-text-accent", 10, SIDEBAR_BG],
+    kind: "text",
+  },
+  {
+    where: ".sidebar a[aria-current=page]::before",
+    what: "2px accent bar — the state indicator, so it carries the active state on its own",
+    fg: "--sl-color-text-accent",
+    bg: ["--sl-color-text-accent", 10, SIDEBAR_BG],
+    kind: "non-text",
+  },
+  {
+    where: ".sidebar a",
+    what: "resting link label on the sidebar background",
+    fg: "--sl-color-text",
+    bg: SIDEBAR_BG,
+    kind: "text",
+  },
+  {
+    where: ".sidebar a:not([aria-current=page]):hover",
+    what: "hovered link label on its ink tint (Starlight sets color: --sl-color-white)",
+    fg: "--sl-color-white",
+    bg: ["--sl-color-text", 6, SIDEBAR_BG],
+    kind: "text",
+  },
+
+  // --- Header (src/components/starlight/Header.astro) -----------------------
+  {
+    where: "Header.astro .docs-badge",
+    what: "badge ink on a 12% tint of the accent it is coloured with",
+    fg: "--sl-color-accent-high",
+    bg: ["--sl-color-text-accent", 12, "--sl-color-bg-nav"],
+    kind: "text",
+  },
+  {
+    where: "Header.astro .docs-badge:hover",
+    what: "badge ink on the 20% hover tint",
+    fg: "--sl-color-accent-high",
+    bg: ["--sl-color-text-accent", 20, "--sl-color-bg-nav"],
+    kind: "text",
+  },
+  {
+    where: "Header.astro .nav-links a",
+    what: "resting header nav link",
+    fg: "--sl-color-text",
+    bg: "--sl-color-bg-nav",
+    kind: "text",
+  },
+  {
+    where: "Header.astro .nav-links a:hover",
+    what: "hovered header nav link on its 7% ink tint",
+    fg: "--sl-color-white",
+    bg: ["--sl-color-text", 7, "--sl-color-bg-nav"],
+    kind: "text",
+  },
+
+  // --- Body content (Starlight markdown.css) -------------------------------
+  {
+    where: ".sl-markdown-content a",
+    what: "body link — Starlight colours every prose link with --sl-color-text-accent",
+    fg: "--sl-color-text-accent",
+    bg: "--sl-color-bg",
+    kind: "text",
+  },
+  {
+    where: ".sl-markdown-content a:hover",
+    what: "hovered body link",
+    fg: "--sl-color-white",
+    bg: "--sl-color-bg",
+    kind: "text",
+  },
+  {
+    where: ":not(pre) > code",
+    what: "inline code on its 8% ink tint",
+    fg: "--sl-color-text",
+    bg: ["--sl-color-text", 8],
+    kind: "text",
+  },
+  {
+    where: "::selection",
+    what: "selected body text on the 25% accent highlight",
+    fg: "--sl-color-text",
+    bg: ["--sl-color-accent", 25],
+    kind: "text",
+  },
+
+  // --- Table of contents ---------------------------------------------------
+  {
+    where: "starlight-toc a[aria-current=true]",
+    what: "active table-of-contents entry",
+    fg: "--sl-color-text-accent",
+    bg: "--sl-color-bg",
+    kind: "text",
+  },
+
+  // --- Accent-coloured surfaces (Starlight SkipLink.astro, FileTree.astro) --
+  // Both pair `color: --sl-color-text-invert` with
+  // `background-color: --sl-color-text-accent`.
+  {
+    where: "SkipLink / FileTree .highlight",
+    what: "inverted ink on the accent surface",
+    fg: "--sl-color-text-invert",
+    bg: "--sl-color-text-accent",
+    kind: "text",
+  },
+
+  // --- Buttons -------------------------------------------------------------
+  {
+    where: ".sl-link-button.primary",
+    what: "white label on the solid accent fill",
+    fg: "#fff",
+    bg: "--ots-accent-solid",
+    kind: "text",
+  },
+  {
+    where: ".sl-link-button.primary:hover",
+    what: "white label on the hovered fill",
+    fg: "#fff",
+    bg: "--ots-accent-solid-hover",
+    kind: "text",
+  },
+  {
+    where: ".sl-link-button.primary",
+    what: "button surface against the page — its own boundary",
+    fg: "--ots-accent-solid",
+    bg: "--sl-color-bg",
+    kind: "non-text",
+  },
+
+  // --- Focus ---------------------------------------------------------------
+  {
+    where: ":focus-visible",
+    what: "focus ring against the page",
+    fg: "--sl-color-text-accent",
+    bg: "--sl-color-bg",
+    kind: "non-text",
+  },
+];
+
+/**
+ * Resolve a PAIRS entry side to a literal colour for `theme`.
+ *
+ * A `--token` name that the stylesheet no longer declares is an error, not a
+ * colour: silently falling through would let a renamed or deleted token quietly
+ * drop its pair out of the audit.
+ */
+function resolve(side, tokens) {
+  const [name, pct, backdrop = "--sl-color-bg"] = Array.isArray(side) ? side : [side, null];
+  for (const token of [name, ...(pct === null ? [] : [backdrop])]) {
+    if (token.startsWith("--") && !(token in tokens)) {
+      throw new Error(
+        `${token} is not declared in src/styles/theme-overrides.css (nor a Starlight base token) — ` +
+          `update PAIRS in bin/check-contrast.mjs if it was renamed`
+      );
+    }
+  }
+  const value = tokens[name] ?? name;
+  if (pct === null) return toHex(parseColor(value));
+  return toHex(mixOver(value, pct, tokens[backdrop] ?? backdrop));
+}
+
+/**
+ * Structural guard: a rule that repaints an active-state SURFACE must restate
+ * its INK in the same block.
+ *
+ * The measured pairs above assume the stylesheet declares both. They cannot
+ * see the failure mode that caused the original bug — a rule that sets only
+ * `background`, leaving Starlight's paired `color` to apply from
+ * `@layer starlight.core` against a surface it was never chosen for. Selecting
+ * on [aria-current] catches the active nav/ToC states, where Starlight always
+ * pairs the two. Pseudo-element rules are decoration, not text, so they are
+ * exempt.
+ */
+function checkRepaintedSurfaces(css) {
+  const problems = [];
+  for (const { selector, decls } of parseRules(css)) {
+    // Drop :not(…) groups first: `a:not([aria-current="page"]):hover` styles the
+    // INACTIVE state, where Starlight's own `a:hover` colour is the right one.
+    const positive = selector.replace(/:not\([^)]*\)/g, "");
+    if (!positive.includes("[aria-current")) continue;
+    if (positive.includes("::before") || positive.includes("::after")) continue;
+    const paintsSurface = "background" in decls || "background-color" in decls;
+    if (paintsSurface && !("color" in decls)) {
+      problems.push(selector);
+    }
+  }
+  return problems;
+}
+
+const failures = [];
+const rows = [];
+
+for (const theme of ["light", "dark"]) {
+  const tokens = resolveTokens(theme);
+
+  for (const pair of PAIRS) {
+    const fg = resolve(pair.fg, tokens);
+    const bg = resolve(pair.bg, tokens);
+    const ratio = round2(contrastRatio(fg, bg));
+    const minimum = AA_MINIMUM[pair.kind];
+    const ok = ratio >= minimum;
+
+    rows.push({ theme, ...pair, fg, bg, ratio, minimum, ok });
+    if (!ok) failures.push({ theme, ...pair, fg, bg, ratio, minimum });
+  }
+}
+
+const pad = (s, n) => String(s).padEnd(n);
+console.log(
+  `${pad("", 4)} ${pad("theme", 6)} ${pad("ratio", 8)} ${pad("min", 6)} ${pad("fg", 9)} ${pad("bg", 9)} rule`
+);
+for (const r of rows) {
+  console.log(
+    `${pad(r.ok ? "ok" : "FAIL", 4)} ${pad(r.theme, 6)} ${pad(`${r.ratio.toFixed(2)}:1`, 8)} ` +
+      `${pad(`${r.minimum.toFixed(1)}:1`, 6)} ${pad(r.fg, 9)} ${pad(r.bg, 9)} ${r.where}`
+  );
+}
+
+const unpaired = checkRepaintedSurfaces(readFileSync(OVERRIDES_CSS, "utf8"));
+
+if (failures.length > 0) {
+  console.error(`\n${failures.length} colour pair(s) below WCAG 2.2 AA:\n`);
+  for (const f of failures) {
+    console.error(
+      `  [${f.theme}] ${f.where}\n` +
+        `    ${f.what}\n` +
+        `    ${f.fg} on ${f.bg} = ${f.ratio.toFixed(2)}:1, needs ${f.minimum.toFixed(1)}:1 (${f.kind})\n`
+    );
+  }
+  console.error("Adjust the tokens in src/styles/theme-overrides.css.");
+}
+
+if (unpaired.length > 0) {
+  console.error(`\n${unpaired.length} active-state rule(s) repaint a surface without restating ink:\n`);
+  for (const selector of unpaired) {
+    console.error(
+      `  ${selector}\n` +
+        `    sets a background but no color, so Starlight's paired\n` +
+        `    color: var(--sl-color-text-invert) applies over it — that token is chosen for a\n` +
+        `    saturated accent fill and is near-invisible on a tint.\n`
+    );
+  }
+  console.error("Declare an explicit `color` alongside the background.");
+}
+
+if (failures.length > 0 || unpaired.length > 0) process.exit(1);
+
+console.log(
+  `\nAll ${rows.length} colour pairs meet WCAG 2.2 AA, and every active-state rule pairs ink with its surface.`
+);

--- a/bin/lib/contrast.mjs
+++ b/bin/lib/contrast.mjs
@@ -1,0 +1,238 @@
+// bin/lib/contrast.mjs
+//
+// Colour maths and token resolution behind the check:contrast drift check.
+// Plain Node ESM, zero dependencies; paths resolve relative to this file so
+// the scripts work from any cwd.
+//
+// The theme tokens are READ OUT of src/styles/theme-overrides.css rather than
+// duplicated here, so editing a colour in the stylesheet is what the check
+// measures. Only Starlight's own base values (the ones the stylesheet does not
+// override) are pinned below.
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+export const OVERRIDES_CSS = join(repoRoot, "src", "styles", "theme-overrides.css");
+
+/**
+ * The greyscale tokens theme-overrides.css leaves alone, as they actually
+ * resolve in a built page.
+ *
+ * NOT Starlight's stock values. @astrojs/starlight-tailwind rewires Starlight's
+ * ramp onto Tailwind's `--color-gray-*` scale from `@layer utilities` (which
+ * outranks Starlight's own `@layer starlight.base`), and src/styles/tailwind.css
+ * in turn aliases `--color-gray-*` to Tailwind's **neutral** scale. So the greys
+ * below are Tailwind neutral, verified against a built page in both themes.
+ *
+ * Two consequences worth keeping in view:
+ *
+ *  - The ramp INVERTS in light mode: --sl-color-white is the darkest ink and
+ *    --sl-color-black is the page background. That inversion is what makes the
+ *    "invert" tokens easy to misread — the class of bug this check exists for.
+ *  - In dark mode the sidebar does NOT sit on the page background:
+ *    --sl-color-bg-sidebar is neutral-800 while --sl-color-bg is neutral-900,
+ *    so sidebar pairs must be measured against the former.
+ */
+export const STARLIGHT_BASE = {
+  light: {
+    "--sl-color-bg": "#ffffff", // --sl-color-black → --color-white
+    "--sl-color-bg-sidebar": "#ffffff", // → var(--sl-color-bg)
+    "--sl-color-bg-nav": "#f5f5f5", // → var(--sl-color-gray-7) → neutral-100
+    "--sl-color-text": "#404040", // --sl-color-gray-2 → neutral-700
+    "--sl-color-gray-3": "#737373", // → neutral-500
+    "--sl-color-white": "#171717", // → neutral-900; darkest ink in light mode
+    "--sl-color-text-invert": "#ffffff", // → var(--sl-color-black)
+  },
+  dark: {
+    "--sl-color-bg": "#171717", // --sl-color-black → neutral-900
+    "--sl-color-bg-sidebar": "#262626", // → var(--sl-color-gray-6) → neutral-800
+    "--sl-color-bg-nav": "#262626", // → var(--sl-color-gray-6) → neutral-800
+    "--sl-color-text": "#d4d4d4", // --sl-color-gray-2 → neutral-300
+    "--sl-color-gray-3": "#a1a1a1", // → neutral-400
+    "--sl-color-white": "#ffffff",
+    "--sl-color-text-invert": "var(--sl-color-accent-low)",
+  },
+};
+
+// --- Colour parsing ---------------------------------------------------------
+
+function hexToRgb(hex) {
+  const h = hex.replace("#", "");
+  const full = h.length === 3 ? h.split("").map((c) => c + c).join("") : h;
+  return [
+    parseInt(full.slice(0, 2), 16),
+    parseInt(full.slice(2, 4), 16),
+    parseInt(full.slice(4, 6), 16),
+  ];
+}
+
+function hslToRgb(h, s, l) {
+  s /= 100;
+  l /= 100;
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const hp = (((h % 360) + 360) % 360) / 60;
+  const x = c * (1 - Math.abs((hp % 2) - 1));
+  const [r, g, b] =
+    hp < 1 ? [c, x, 0]
+    : hp < 2 ? [x, c, 0]
+    : hp < 3 ? [0, c, x]
+    : hp < 4 ? [0, x, c]
+    : hp < 5 ? [x, 0, c]
+    : [c, 0, x];
+  const m = l - c / 2;
+  return [r + m, g + m, b + m].map((v) => Math.round(v * 255));
+}
+
+/** Parse a `#rgb`, `#rrggbb` or `hsl(h, s%, l%)` string to `[r, g, b]` 0-255. */
+export function parseColor(color) {
+  if (Array.isArray(color)) return color;
+  const c = String(color).trim();
+  if (c.startsWith("#")) return hexToRgb(c);
+  const hsl = c.match(/^hsl\(\s*([\d.]+)[,\s]+([\d.]+)%[,\s]+([\d.]+)%\s*\)$/i);
+  if (hsl) return hslToRgb(Number(hsl[1]), Number(hsl[2]), Number(hsl[3]));
+  throw new Error(`unsupported colour syntax: ${color}`);
+}
+
+/** Format `[r, g, b]` as `#rrggbb`. */
+export function toHex(rgb) {
+  return "#" + rgb.map((v) => Math.round(v).toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * Composite `color-mix(in srgb, <color> <pct>%, transparent)` over an opaque
+ * backdrop — i.e. what the eye actually sees where a translucent tint sits on
+ * the page. Straight alpha blend; sRGB, matching the `in srgb` colour space
+ * the stylesheet asks for.
+ */
+export function mixOver(color, pct, backdrop) {
+  const c = parseColor(color);
+  const b = parseColor(backdrop);
+  const a = pct / 100;
+  return c.map((v, i) => Math.round(a * v + (1 - a) * b[i]));
+}
+
+// --- WCAG 2.2 contrast ------------------------------------------------------
+
+/** Relative luminance, WCAG 2.2 definition. */
+export function luminance(color) {
+  const [r, g, b] = parseColor(color).map((v) => {
+    const s = v / 255;
+    return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/** Contrast ratio between two colours, 1:1 … 21:1. */
+export function contrastRatio(fg, bg) {
+  const a = luminance(fg);
+  const b = luminance(bg);
+  const [hi, lo] = a > b ? [a, b] : [b, a];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/**
+ * Minimum ratio for a pair, per WCAG 2.2.
+ *
+ * - `text`      SC 1.4.3 Contrast (Minimum), AA — 4.5:1
+ * - `large`     SC 1.4.3 for >=24px, or >=18.66px bold — 3:1
+ * - `non-text`  SC 1.4.11 Non-text Contrast — 3:1 for UI component boundaries
+ *               and meaningful graphics
+ */
+export const AA_MINIMUM = { text: 4.5, large: 3, "non-text": 3 };
+
+/** Round half-up to 2dp, so a printed "4.50:1" is never a rounded-up 4.497. */
+export function round2(n) {
+  return Math.round(n * 100) / 100;
+}
+
+// --- Token resolution -------------------------------------------------------
+
+/**
+ * Extract custom-property declarations from a CSS rule block.
+ *
+ * Deliberately small: it reads the two flat `:root` blocks at the top of
+ * theme-overrides.css, not arbitrary CSS. Trailing `/* … *\/` comments on a
+ * declaration are stripped.
+ *
+ * @param {string} css Full stylesheet text.
+ * @param {string} selector Exact selector text to match, e.g. `:root`.
+ * @returns {Record<string, string>} Declared custom properties.
+ */
+export function parseRootBlock(css, selector) {
+  // Strip block comments first so a `{` or `}` inside prose cannot end the rule.
+  const stripped = css.replace(/\/\*[\s\S]*?\*\//g, "");
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const block = stripped.match(new RegExp(`(?:^|\\})\\s*${escaped}\\s*\\{([^}]*)\\}`));
+  if (!block) throw new Error(`no "${selector}" block in stylesheet`);
+
+  const tokens = {};
+  for (const decl of block[1].split(";")) {
+    const m = decl.match(/^\s*(--[\w-]+)\s*:\s*(.+?)\s*$/);
+    if (m) tokens[m[1]] = m[2];
+  }
+  return tokens;
+}
+
+/**
+ * Split a flat stylesheet into `{ selector, decls }` rules.
+ *
+ * Comments are stripped first. theme-overrides.css is deliberately flat — no
+ * `@media` or other nesting — so a top-level scan is sufficient; any rule
+ * nested inside an at-rule would be skipped, and the check would need
+ * extending alongside it.
+ *
+ * @param {string} css
+ * @returns {{selector: string, decls: Record<string, string>}[]}
+ */
+export function parseRules(css) {
+  const stripped = css.replace(/\/\*[\s\S]*?\*\//g, "");
+  const rules = [];
+  for (const [, selector, body] of stripped.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    const decls = {};
+    for (const decl of body.split(";")) {
+      const m = decl.match(/^\s*([\w-]+)\s*:\s*(.+?)\s*$/s);
+      if (m) decls[m[1]] = m[2];
+    }
+    rules.push({ selector: selector.trim().replace(/\s+/g, " "), decls });
+  }
+  return rules;
+}
+
+/**
+ * Resolve the effective token table for one theme.
+ *
+ * Cascade note: theme-overrides.css is loaded through Starlight's `customCss`
+ * with no `@layer` wrapper, and unlayered rules beat every layered rule
+ * regardless of specificity. Starlight's own props live in
+ * `@layer starlight.base`, so anything the stylesheet declares wins outright —
+ * and anything it omits falls through to STARLIGHT_BASE.
+ *
+ * @param {'light'|'dark'} theme
+ * @param {string} [css] Stylesheet text; defaults to the repo's own.
+ * @returns {Record<string, string>} Token name → literal colour.
+ */
+export function resolveTokens(theme, css = readFileSync(OVERRIDES_CSS, "utf8")) {
+  const declared = {
+    ...parseRootBlock(css, ":root"),
+    ...(theme === "dark" ? parseRootBlock(css, ':root[data-theme="dark"]') : {}),
+  };
+  const merged = { ...STARLIGHT_BASE[theme], ...declared };
+
+  // Follow `var(--x)` aliases to a literal. Starlight's own defaults use them;
+  // one hop is all its props.css ever needs, but loop defensively.
+  const resolved = {};
+  for (const [name, value] of Object.entries(merged)) {
+    let v = value;
+    for (let hop = 0; hop < 8; hop++) {
+      const alias = v.match(/^var\(\s*(--[\w-]+)\s*\)$/);
+      if (!alias) break;
+      const next = merged[alias[1]];
+      if (next === undefined) throw new Error(`${name}: unknown token ${alias[1]}`);
+      v = next;
+    }
+    resolved[name] = v;
+  }
+  return resolved;
+}

--- a/bin/lib/contrast.mjs
+++ b/bin/lib/contrast.mjs
@@ -60,6 +60,9 @@ export const STARLIGHT_BASE = {
 
 function hexToRgb(hex) {
   const h = hex.replace("#", "");
+  if (h.length !== 3 && h.length !== 6) {
+    throw new Error(`unsupported hex colour: #${h}`);
+  }
   const full = h.length === 3 ? h.split("").map((c) => c + c).join("") : h;
   return [
     parseInt(full.slice(0, 2), 16),
@@ -221,7 +224,9 @@ export function resolveTokens(theme, css = readFileSync(OVERRIDES_CSS, "utf8")) 
   const merged = { ...STARLIGHT_BASE[theme], ...declared };
 
   // Follow `var(--x)` aliases to a literal. Starlight's own defaults use them;
-  // one hop is all its props.css ever needs, but loop defensively.
+  // one hop is all its props.css ever needs, but loop defensively. The 8-hop
+  // cap is cycle protection, not correctness: a cyclic alias exhausts the loop
+  // and leaves a `var(...)` value that parseColor rejects downstream.
   const resolved = {};
   for (const [name, value] of Object.entries(merged)) {
     let v = value;

--- a/bin/lib/contrast.test.mjs
+++ b/bin/lib/contrast.test.mjs
@@ -37,6 +37,12 @@ describe("parseColor", () => {
     expect(() => parseColor("rgb(1 2 3)")).toThrow(/unsupported/);
     expect(() => parseColor("var(--nope)")).toThrow(/unsupported/);
   });
+
+  it("rejects hex lengths it cannot evaluate rather than yielding NaN channels", () => {
+    expect(() => parseColor("#ffff")).toThrow(/unsupported/); // 4-digit (alpha)
+    expect(() => parseColor("#ffffff80")).toThrow(/unsupported/); // 8-digit (alpha)
+    expect(() => parseColor("#ff")).toThrow(/unsupported/);
+  });
 });
 
 describe("luminance / contrastRatio", () => {

--- a/bin/lib/contrast.test.mjs
+++ b/bin/lib/contrast.test.mjs
@@ -1,0 +1,196 @@
+// bin/lib/contrast.test.mjs
+//
+// Unit tests for the pure helpers behind the check:contrast drift check. The
+// check itself is an executable assertion over the real stylesheet; these cover
+// the maths and the parsing edge cases that would otherwise regress silently.
+import { describe, expect, it } from "vitest";
+
+import {
+  AA_MINIMUM,
+  STARLIGHT_BASE,
+  contrastRatio,
+  luminance,
+  mixOver,
+  parseColor,
+  parseRootBlock,
+  parseRules,
+  resolveTokens,
+  round2,
+  toHex,
+} from "./contrast.mjs";
+
+describe("parseColor", () => {
+  it("reads long and short hex", () => {
+    expect(parseColor("#ffffff")).toEqual([255, 255, 255]);
+    expect(parseColor("#000")).toEqual([0, 0, 0]);
+    expect(parseColor("#dc4a22")).toEqual([220, 74, 34]);
+  });
+
+  it("reads hsl(), which is how Starlight writes its stock ramp", () => {
+    expect(parseColor("hsl(0, 0%, 100%)")).toEqual([255, 255, 255]);
+    expect(parseColor("hsl(0, 0%, 0%)")).toEqual([0, 0, 0]);
+    // Starlight's stock --sl-color-black, documented in its source as #17181c.
+    expect(toHex(parseColor("hsl(224, 10%, 10%)"))).toBe("#17181c");
+  });
+
+  it("rejects syntax it cannot faithfully evaluate", () => {
+    expect(() => parseColor("rgb(1 2 3)")).toThrow(/unsupported/);
+    expect(() => parseColor("var(--nope)")).toThrow(/unsupported/);
+  });
+});
+
+describe("luminance / contrastRatio", () => {
+  it("matches the WCAG reference extremes", () => {
+    expect(luminance("#ffffff")).toBeCloseTo(1, 10);
+    expect(luminance("#000000")).toBeCloseTo(0, 10);
+    expect(contrastRatio("#000000", "#ffffff")).toBeCloseTo(21, 10);
+  });
+
+  it("is 1:1 for a colour against itself, and order-independent", () => {
+    expect(contrastRatio("#dc4a22", "#dc4a22")).toBeCloseTo(1, 10);
+    expect(contrastRatio("#000", "#fff")).toBeCloseTo(contrastRatio("#fff", "#000"), 10);
+  });
+
+  it("agrees with published ratios for known pairs", () => {
+    // #767676 on white is the canonical "smallest grey that passes AA".
+    expect(round2(contrastRatio("#767676", "#ffffff"))).toBe(4.54);
+    // Tailwind blue-600 on white.
+    expect(round2(contrastRatio("#2563eb", "#ffffff"))).toBe(5.17);
+  });
+});
+
+describe("mixOver", () => {
+  it("composites a translucent tint onto an opaque backdrop", () => {
+    // color-mix(in srgb, #dc4a22 10%, transparent) over white.
+    expect(toHex(mixOver("#dc4a22", 10, "#ffffff"))).toBe("#fcede9");
+    expect(toHex(mixOver("#c43d1b", 10, "#ffffff"))).toBe("#f9ece8");
+  });
+
+  it("returns the backdrop at 0% and the colour at 100%", () => {
+    expect(toHex(mixOver("#dc4a22", 0, "#ffffff"))).toBe("#ffffff");
+    expect(toHex(mixOver("#dc4a22", 100, "#ffffff"))).toBe("#dc4a22");
+  });
+});
+
+describe("parseRootBlock", () => {
+  it("reads declarations and ignores trailing comments", () => {
+    const css = `
+      :root {
+        --a: #111; /* a note */
+        --b: #222;
+      }
+    `;
+    expect(parseRootBlock(css, ":root")).toEqual({ "--a": "#111", "--b": "#222" });
+  });
+
+  it("does not let a brace inside a comment end the rule", () => {
+    const css = `
+      /* prose mentioning a { brace } inside a comment */
+      :root { --a: #111; }
+    `;
+    expect(parseRootBlock(css, ":root")).toEqual({ "--a": "#111" });
+  });
+
+  it("keeps :root and :root[data-theme] blocks distinct", () => {
+    const css = `
+      :root { --a: #111; }
+      :root[data-theme="dark"] { --a: #222; }
+    `;
+    expect(parseRootBlock(css, ":root")["--a"]).toBe("#111");
+    expect(parseRootBlock(css, ':root[data-theme="dark"]')["--a"]).toBe("#222");
+  });
+
+  it("throws when the block is missing rather than reporting an empty theme", () => {
+    expect(() => parseRootBlock("a { color: red; }", ":root")).toThrow(/no ":root" block/);
+  });
+});
+
+describe("resolveTokens", () => {
+  const css = `
+    :root {
+      --sl-color-text-accent: #c43d1b;
+    }
+    :root[data-theme="dark"] {
+      --sl-color-text-accent: #e8663f;
+      --sl-color-accent-low: #85200c;
+    }
+  `;
+
+  it("layers the dark block over :root, and :root alone for light", () => {
+    expect(resolveTokens("light", css)["--sl-color-text-accent"]).toBe("#c43d1b");
+    expect(resolveTokens("dark", css)["--sl-color-text-accent"]).toBe("#e8663f");
+  });
+
+  it("falls back to Starlight's base values for tokens the sheet leaves alone", () => {
+    expect(resolveTokens("light", css)["--sl-color-bg"]).toBe(STARLIGHT_BASE.light["--sl-color-bg"]);
+    expect(resolveTokens("dark", css)["--sl-color-bg"]).toBe(STARLIGHT_BASE.dark["--sl-color-bg"]);
+  });
+
+  it("follows var() aliases to a literal colour", () => {
+    // Starlight's dark --sl-color-text-invert aliases --sl-color-accent-low.
+    expect(resolveTokens("dark", css)["--sl-color-text-invert"]).toBe("#85200c");
+  });
+
+  it("throws on an alias to a token nothing declares", () => {
+    expect(() => resolveTokens("light", ":root { --x: var(--missing); }")).toThrow(/unknown token/);
+  });
+});
+
+describe("parseRules", () => {
+  it("returns each rule's selector and declarations", () => {
+    const rules = parseRules(`
+      .a { color: red; background: blue; }
+      .b, .c { color: green; }
+    `);
+    expect(rules).toEqual([
+      { selector: ".a", decls: { color: "red", background: "blue" } },
+      { selector: ".b, .c", decls: { color: "green" } },
+    ]);
+  });
+
+  it("ignores commented-out rules", () => {
+    expect(parseRules("/* .a { color: red; } */ .b { color: green; }")).toEqual([
+      { selector: ".b", decls: { color: "green" } },
+    ]);
+  });
+});
+
+// --- Regression: the bug this check exists to prevent ------------------------
+//
+// Starlight's SidebarSublist.astro pairs
+//   color: var(--sl-color-text-invert)  with  background-color: var(--sl-color-text-accent)
+// — inverted ink on a SATURATED accent fill. theme-overrides.css replaced that
+// background with a 10% tint. Restating the background without the ink stranded
+// --sl-color-text-invert on a surface it was never chosen for.
+describe("sidebar active link regression", () => {
+  it("is unreadable when Starlight's invert ink is left on a 10% tint", () => {
+    // Light: --sl-color-text-invert resolves to #ffffff (the ramp inverts, so
+    // --sl-color-black is the page background in light mode).
+    const lightTint = mixOver("#dc4a22", 10, STARLIGHT_BASE.light["--sl-color-bg-sidebar"]);
+    expect(round2(contrastRatio("#ffffff", lightTint))).toBe(1.14);
+
+    // Dark: it resolves to --sl-color-accent-low, #85200c in this theme.
+    const darkTint = mixOver("#e8663f", 10, STARLIGHT_BASE.dark["--sl-color-bg-sidebar"]);
+    expect(round2(contrastRatio("#85200c", darkTint))).toBe(1.41);
+  });
+
+  it("clears AA once the tint carries accent-high as its ink", () => {
+    const tokens = { light: resolveTokens("light"), dark: resolveTokens("dark") };
+
+    for (const theme of ["light", "dark"]) {
+      const t = tokens[theme];
+      const tint = mixOver(t["--sl-color-text-accent"], 10, t["--sl-color-bg-sidebar"]);
+      const ratio = contrastRatio(t["--sl-color-accent-high"], tint);
+      expect(ratio, `${theme} sidebar active link`).toBeGreaterThanOrEqual(AA_MINIMUM.text);
+    }
+  });
+
+  it("keeps --sl-color-text-invert readable on the accent surface it inks", () => {
+    // SkipLink.astro and FileTree.astro both pair these two directly.
+    for (const theme of ["light", "dark"]) {
+      const t = resolveTokens(theme);
+      const ratio = contrastRatio(t["--sl-color-text-invert"], t["--sl-color-text-accent"]);
+      expect(ratio, `${theme} skip link`).toBeGreaterThanOrEqual(AA_MINIMUM.text);
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "check:nav": "node bin/check-nav.mjs",
     "check:orphans": "node bin/check-orphans.mjs",
     "check:locales": "node bin/check-locales.mjs",
+    "check:contrast": "node bin/check-contrast.mjs",
     "check:links": "./bin/check-links.sh",
     "check:links:malformed": "./bin/check-malformed-links.sh",
     "check:links:get": "./bin/check-links.sh --get --external",

--- a/src/components/artifacts/ExampleReactDemo.jsx
+++ b/src/components/artifacts/ExampleReactDemo.jsx
@@ -27,7 +27,8 @@ export default function ExampleReactDemo() {
         onClick={() => setCount(count + 1)}
         style={{
           padding: "0.5rem 1rem",
-          backgroundColor: "#3b82f6",
+          // blue-600, not blue-500: white on #3b82f6 is 3.68:1, under AA.
+          backgroundColor: "#2563eb",
           color: "white",
           border: "none",
           borderRadius: "0.25rem",

--- a/src/components/config-generator/ConfigGenerator.vue
+++ b/src/components/config-generator/ConfigGenerator.vue
@@ -397,4 +397,10 @@
     font-size: 0.8rem;
     color: var(--sl-color-gray-3);
   }
+  /* Inline code in the note sits on the tinted inline-code background, which
+     drops muted gray-3 ink to 4.16:1 in light mode. Step the code up to body
+     ink (9.10:1) — the note prose itself stays muted on the plain background. */
+  .cg-note code {
+    color: var(--sl-color-text);
+  }
 </style>

--- a/src/components/starlight/Header.astro
+++ b/src/components/starlight/Header.astro
@@ -65,6 +65,10 @@ const blogLink = 'https://blog.onetimesecret.com/';
 		gap: 0.625rem;
 	}
 
+	/* Ink is --sl-color-accent-high, not --sl-color-text-accent: the badge sits on
+	   a 12% tint of the accent itself, and accent-on-its-own-tint is only ~4:1 —
+	   under the 4.5:1 AA floor for 11px text. accent-high is the token meant for
+	   accent-coloured ink and clears it in both themes (5.52:1 / 8.02:1). */
 	.docs-badge {
 		display: none;
 		font-size: 0.6875rem;
@@ -72,7 +76,7 @@ const blogLink = 'https://blog.onetimesecret.com/';
 		letter-spacing: 0.05em;
 		text-transform: uppercase;
 		text-decoration: none;
-		color: var(--sl-color-text-accent);
+		color: var(--sl-color-accent-high);
 		background: color-mix(in srgb, var(--sl-color-text-accent) 12%, transparent);
 		padding: 0.1875rem 0.5rem;
 		border-radius: 5px;
@@ -110,8 +114,12 @@ const blogLink = 'https://blog.onetimesecret.com/';
     margin-left: 0.25rem;
   }
 
+  /* --sl-color-gray-3 is only 4.35:1 on the light nav background, so the resting
+     state uses --sl-color-text and hover steps up to --sl-color-white. Same
+     resting/hover pairing Starlight uses for sidebar links, and it keeps a
+     visible hover step in both themes. */
   .nav-links a {
-    color: var(--sl-color-gray-3);
+    color: var(--sl-color-text);
     text-decoration: none;
     font-size: 0.8125rem;
     font-weight: 500;
@@ -122,7 +130,7 @@ const blogLink = 'https://blog.onetimesecret.com/';
   }
 
   .nav-links a:hover {
-    color: var(--sl-color-text);
+    color: var(--sl-color-white);
     background: color-mix(in srgb, var(--sl-color-text) 7%, transparent);
   }
 

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -75,7 +75,11 @@ const docsHref = `/${defaultLocale}/introduction/`;
     <!-- Two distinct actions: keep reading the docs, or jump to the app.
          data-doclink links are re-pointed to the visitor's locale at runtime. -->
     <div class="flex flex-col sm:flex-row gap-4 justify-center mb-16 not-content">
-      <a data-doclink data-i18n="browseDocs" href={docsHref} class="bg-brand-500 text-white hover:bg-brand-600 px-6 py-2 rounded-lg font-medium transition-colors">
+      <!-- brand-600, not brand-500: white on brand-500 (#dc4a22) is 4.16:1, under
+           the 4.5:1 AA floor for this 16px label. brand-600 gives 5.21:1 and the
+           brand-700 hover 7.14:1 — the same pair the primary button uses in
+           src/styles/theme-overrides.css. -->
+      <a data-doclink data-i18n="browseDocs" href={docsHref} class="bg-brand-600 text-white hover:bg-brand-700 px-6 py-2 rounded-lg font-medium transition-colors">
         {d.browseDocs}
       </a>
       <a data-i18n="goToApp" href="https://onetimesecret.com" class="border border-gray-400 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:border-brand-500 px-6 py-2 rounded-lg font-medium transition-colors">

--- a/src/pages/artifacts/2026/sso-demos/index.astro
+++ b/src/pages/artifacts/2026/sso-demos/index.astro
@@ -116,7 +116,10 @@ const demos = [
           </h3>
           <div class="h-px flex-1 bg-gradient-to-r from-transparent via-gray-600 to-transparent" />
         </div>
-        <p class="mt-4 text-center text-sm text-gray-500">
+        <!-- gray-400, not gray-500: on this dark panel gray-500 is 3.59:1, under
+             the 4.5:1 AA floor. gray-400 gives 6.60:1 and matches the muted text
+             used elsewhere on the page. -->
+        <p class="mt-4 text-center text-sm text-gray-400">
           Planned demos include SP-initiated SAML login, SCIM provisioning flows, and multi-IdP federation patterns.
         </p>
       </div>
@@ -124,7 +127,8 @@ const demos = [
       {/* Footer */}
       <footer class="mt-auto pt-16 text-center">
         <div class="border-t border-gray-800 pt-8">
-          <p class="text-sm text-gray-500">
+          <!-- gray-400 (6.94:1) — gray-500 is 3.78:1 on this background. -->
+          <p class="text-sm text-gray-400">
             These demonstrations are designed for technical analysts evaluating SSO integration patterns.
           </p>
           <p class="mt-3">

--- a/src/pages/artifacts/astro-react-demo.astro
+++ b/src/pages/artifacts/astro-react-demo.astro
@@ -84,7 +84,9 @@ const pageDescription = "Reference implementation demonstrating React component 
     }
 
     footer a {
-      color: #3b82f6;
+      /* blue-600, not blue-500: #3b82f6 on white is 3.68:1, under the 4.5:1 AA
+         floor for this 14px link. */
+      color: #2563eb;
       text-decoration: none;
     }
 

--- a/src/styles/theme-overrides.css
+++ b/src/styles/theme-overrides.css
@@ -5,19 +5,53 @@
    Modern SaaS documentation styling
    ======================================================================== */
 
-/* --- Accent Colors --- */
+/* --- Accent Colors ---
+ *
+ * Contrast budget (WCAG 2.2 SC 1.4.3, AA): every token below that is used as
+ * TEXT clears 4.5:1 against the surface it lands on, and every token used as a
+ * SURFACE clears 4.5:1 against the ink Starlight puts on it. Ratios in the
+ * comments are measured against the page background of the matching theme
+ * (#ffffff light / #171717 dark — the greyscale comes from Tailwind's neutral
+ * scale via @astrojs/starlight-tailwind, not Starlight's stock ramp).
+ *
+ * `pnpm run check:contrast` re-measures all of this against the real tokens.
+ *
+ * --sl-color-text-accent is the load-bearing one: Starlight uses it for body
+ * links (markdown.css), the active table-of-contents entry, the site title, and
+ * the skip link's background. The brand orange #dc4a22 only reaches 4.16:1 on
+ * white, so light mode uses the next shade down (#c43d1b, brand-600) which
+ * clears AA both as ink on white AND as a surface under white ink. Dark mode
+ * keeps #e8663f (5.47:1 on the dark page background).
+ */
 :root {
   --sl-color-accent-low: #fcf4e8;
   --sl-color-accent: #dc4a22;
-  --sl-color-accent-high: #a32d12;
-  --sl-color-text-accent: #dc4a22;
+  --sl-color-accent-high: #a32d12; /* 7.14:1 — readable accent ink */
+  --sl-color-text-accent: #c43d1b; /* 5.21:1 (was #dc4a22 at 4.16:1) */
+
+  /* Starlight leaves this as --sl-color-black, which is #ffffff in light mode.
+     Pinned explicitly because it is the ink for accent-coloured surfaces (skip
+     link, banner) and must not drift with the greyscale ramp. */
+  --sl-color-text-invert: #ffffff;
+
+  /* Solid accent surface for filled controls. Kept theme-independent so a
+     filled button carries white ink at AA in both themes — the dark-mode
+     --sl-color-text-accent is deliberately light for use as ink, which makes
+     it too light to sit *under* white ink. */
+  --ots-accent-solid: #c43d1b; /* white ink: 5.21:1 */
+  --ots-accent-solid-hover: #a32d12; /* white ink: 7.14:1 */
 }
 
 :root[data-theme="dark"] {
   --sl-color-accent-low: #85200c;
   --sl-color-accent: #dc4a22;
-  --sl-color-accent-high: #f0c39e;
-  --sl-color-text-accent: #e8663f;
+  --sl-color-accent-high: #f0c39e; /* 11.10:1 — readable accent ink */
+  --sl-color-text-accent: #e8663f; /* 5.47:1 */
+
+  /* Ink for accent-coloured surfaces. Starlight's dark default resolves to
+     --sl-color-accent-low (#85200c above), which only reaches 2.90:1 on
+     --sl-color-text-accent — near-invisible on the skip link. */
+  --sl-color-text-invert: #2b0703; /* on #e8663f: 5.64:1 */
 }
 
 
@@ -43,9 +77,31 @@ header.header {
   transition: color 0.15s ease, background-color 0.15s ease;
 }
 
-/* Active sidebar link - accent indicator */
-.sidebar a[aria-current="page"] {
+/* Active sidebar link - accent indicator
+ *
+ * `color` MUST be set alongside `background` here. Starlight's own rule
+ * (SidebarSublist.astro, @layer starlight.core) pairs them:
+ *
+ *   [aria-current='page'] { color: var(--sl-color-text-invert);
+ *                           background-color: var(--sl-color-text-accent); }
+ *
+ * i.e. inverted ink on a *saturated* accent fill. Replacing only the background
+ * with a 10% tint left that inverted ink stranded on a near-white surface —
+ * #ffffff on #fcede9, a contrast ratio of 1.14:1 in light mode (and 1.41:1 in
+ * dark, where the inherited invert colour resolved to #85200c). Both are far
+ * below the 4.5:1 AA floor and the link read as blank.
+ *
+ * --sl-color-accent-high is the token meant for accent-coloured ink, so it
+ * carries the active state legibly on the tint: 6.18:1 light, 8.30:1 dark.
+ *
+ * This rule is unlayered, so it also wins over Starlight's :hover / :focus
+ * variants of the same selector without needing !important.
+ */
+.sidebar a[aria-current="page"],
+.sidebar a[aria-current="page"]:hover,
+.sidebar a[aria-current="page"]:focus {
   background: color-mix(in srgb, var(--sl-color-text-accent) 10%, transparent);
+  color: var(--sl-color-accent-high);
   font-weight: 600;
   position: relative;
 }
@@ -68,19 +124,25 @@ header.header {
 }
 
 
-/* --- Primary Buttons --- */
+/* --- Primary Buttons ---
+ *
+ * Filled with --ots-accent-solid rather than --sl-color-text-accent: the latter
+ * is tuned to be *ink* in each theme, so in dark mode it is light enough
+ * (#e8663f) that white label text on it fell to 3.28:1. The solid token is the
+ * same in both themes and holds white at 5.21:1 / 7.14:1 on hover.
+ */
 .sl-link-button.primary {
-  background: var(--sl-color-text-accent);
-  border-color: var(--sl-color-text-accent);
-  color: white;
+  background: var(--ots-accent-solid);
+  border-color: var(--ots-accent-solid);
+  color: #fff;
   border-radius: 8px;
   font-weight: 600;
   transition: background 0.15s ease, transform 0.1s ease;
 }
 
 .sl-link-button.primary:hover {
-  background: #c43d1b;
-  border-color: #c43d1b;
+  background: var(--ots-accent-solid-hover);
+  border-color: var(--ots-accent-solid-hover);
   transform: translateY(-1px);
 }
 

--- a/src/styles/theme-overrides.css
+++ b/src/styles/theme-overrides.css
@@ -79,7 +79,7 @@ header.header {
 
 /* Active sidebar link - accent indicator
  *
- * `color` MUST be set alongside `background` here. Starlight's own rule
+ * `color` MUST be set alongside `background-color` here. Starlight's own rule
  * (SidebarSublist.astro, @layer starlight.core) pairs them:
  *
  *   [aria-current='page'] { color: var(--sl-color-text-invert);
@@ -100,7 +100,7 @@ header.header {
 .sidebar a[aria-current="page"],
 .sidebar a[aria-current="page"]:hover,
 .sidebar a[aria-current="page"]:focus {
-  background: color-mix(in srgb, var(--sl-color-text-accent) 10%, transparent);
+  background-color: color-mix(in srgb, var(--sl-color-text-accent) 10%, transparent);
   color: var(--sl-color-accent-high);
   font-weight: 600;
   position: relative;
@@ -120,7 +120,7 @@ header.header {
 
 /* Sidebar hover state */
 .sidebar a:not([aria-current="page"]):hover {
-  background: color-mix(in srgb, var(--sl-color-text) 6%, transparent);
+  background-color: color-mix(in srgb, var(--sl-color-text) 6%, transparent);
 }
 
 
@@ -178,7 +178,7 @@ header.header {
 
 /* Inline code styling */
 :not(pre) > code {
-  background: color-mix(in srgb, var(--sl-color-text) 8%, transparent);
+  background-color: color-mix(in srgb, var(--sl-color-text) 8%, transparent);
   border-radius: 4px;
   padding: 0.15em 0.35em;
   font-size: 0.875em;


### PR DESCRIPTION
https://claude.ai/code/session_01TmKmdFUoGZXVwKYxCAyaHZ