### PR TITLE
docs(planning): scope stream A's re-verification pass, name the billing/pricing overlap

### DIFF
--- a/docs/planning/documentation-audit-2026-08-phase-3-handoff.md
+++ b/docs/planning/documentation-audit-2026-08-phase-3-handoff.md
@@ -1,0 +1,266 @@
+# Phase 3 handoff — picking this up locally
+
+**What this is:** everything you need to continue Phase 3 on your own machine, written 2026-08-09 at
+the point where the remote session stopped. It is deliberately concrete: the facts already
+established so you do not re-derive them, the decisions still open, and the exact starting points for
+the work that has not begun.
+
+Read alongside — but not instead of —
+[`…-phase-3-prep.md`](./documentation-audit-2026-08-phase-3-prep.md) (the plan) and
+[`…-phase-3-reverification.md`](./documentation-audit-2026-08-phase-3-reverification.md) (stream A's
+completed pass).
+
+---
+
+## 1. Where things stand
+
+| | |
+|---|---|
+| Branch | `claude/phase-3-docs-audit-prep-mixz90` |
+| PR | [#408](https://github.com/onetimesecret/docs.onetimesecret.com/pull/408), draft, base `develop` |
+| Last commit | `55dcd55` — stream A re-verification |
+| Checks at handoff | `check:frontmatter` 63 EN pages · `check:nav` 64 links, 1 known warning · `check:orphans` 0 · `pnpm test` 86 passing |
+
+Nothing on this branch touches page content except one `sourceOfTruth` line in `billing/index.md`.
+Everything else is planning documents. **No pages have been written, split, moved or deleted.**
+
+### Streams, honestly
+
+| Stream | State |
+|---|---|
+| **A** — operator ledger | Backward pass over the six tail pages **done**. Its own forward research (the factual spine for the 26 pages) **not started**. |
+| **B** — split & nav mechanics | **Not started.** §5 below is reconnaissance I gathered for you, not the plan the prep doc asks stream B to produce. |
+| **C** — redirects & shim repoint | **Not started.** Depends on B. Inputs in §6. |
+| **D** — content, 26 pages | **Not started.** Blocked on the §4.1 decision. |
+| **E** — adversarial verify + checkers | **Not started.** Depends on D. |
+
+---
+
+## 2. Local setup
+
+You need the app repo beside the docs repo. Everything in §3 was verified against a specific commit,
+so pin to it if you want the line numbers to match exactly:
+
+```sh
+git clone https://github.com/onetimesecret/onetimesecret.git
+cd onetimesecret && git fetch --unshallow      # blame/log/bisect need full history
+git log -1 --format=%H                          # verified against 6af1fe3 (2026-08-08)
+```
+
+The docs repo side is just `pnpm install`. The checks you will live in:
+
+```sh
+pnpm check:frontmatter   # audience/pageType/sourceOfTruth + the stated-default rule
+pnpm check:nav           # sidebar links resolve
+pnpm check:orphans       # every page reachable
+pnpm check:locales
+pnpm test && pnpm build
+```
+
+**Vale did not run in the remote session** (`npx vale` fails with `ENOVERSIONS` there). If you have
+it locally, run it over the three planning documents — they have not been prose-linted.
+
+---
+
+## 3. Verified facts — do not re-derive these
+
+All against `onetimesecret@6af1fe3`. Full reasoning in the re-verification document; this is the
+lookup table.
+
+**Roles and permissions.** Three roles nest owner ⊃ admin ⊃ member, composed at
+`organization_membership.rb:102-106` from `MEMBER_ENTITLEMENTS:72` / `ADMIN_ENTITLEMENTS:79` /
+`OWNER_ENTITLEMENTS`. Effective permission is a real set intersection —
+`with_materialized_entitlements.rb:13-18`, `org.materialized_entitlements ∩ ROLE_ENTITLEMENTS[role]`.
+
+**Owner invariants, and the surface split that matters.** The in-app API refuses removing *any* owner
+(`remove_member.rb:161-166`) and refuses self-removal (`:169-175`); the role-change endpoint accepts
+only `member` and `admin` (`update_member_role.rb:29`), refuses changing an owner's role (`:163-171`)
+and refuses promoting to owner (`:188-194`). **But the CLI/operations layer is more permissive**: it
+only refuses the *sole* owner (`memberships/remove.rb:80` → `support.rb:20-24 sole_owner?`). So a
+non-sole owner *can* be removed by an operator. The end-user page's "an owner cannot be removed at
+all" is correct for its audience and **must not be repeated on an operator page.**
+
+**Domain scoping is structural, not a role consequence.** `update_member_role.rb:49-50` and
+`remove_member.rb:48-49` both refuse `domain_scoped?` actors *before* any role logic runs.
+
+**Ownership transfer is a real command.** `bin/ots org transfer-ownership ORG NEW_OWNER` —
+`lib/onetime/operations/org/transfer_ownership.rb` (371 lines) plus
+`lib/onetime/cli/org/transfer_ownership_command.rb`. Has `--dry-run` and `--demote-to`
+(`SetRole::VALID_ROLES - ['owner']`). Does **not** auto-add the new owner if they are not already an
+active member (D28); does **not** remove the outgoing owner (D27). Promotes before demoting so the
+sole-owner guard never trips. Idempotent. Transiently fails `bin/ots org doctor` mid-flight. REST
+endpoint unbuilt.
+
+**The governing fact for the whole operator tree.** `with_plan_entitlements.rb:44-62` —
+`STANDALONE_ENTITLEMENTS` is the full set, granted when billing is disabled or the plan cache is
+empty; `:32` says limits return `Float::INFINITY`. Billing is off unless a config turns it on
+(`billing_config.rb:41-53`: "Returns false if file doesn't exist or enabled is not set"), and the
+production `etc/billing.yaml` is in neither repo. **Stock self-hosted = every entitlement granted,
+every limit infinite, role is the whole answer.** This is structural to standalone mode, not a knob.
+`BILLING_ENABLED` overrides it and raises `Onetime::ConfigError` on any value other than
+`true/1/false/0`.
+
+**Receipts.** The withheld-share-link claim is confirmed exactly at its cited lines and fails closed:
+`receipt.rb:93-96` maps `incoming ⇒ shows_share_link: false`, `:98-101` withholds for any unrecognised
+source. Two independent gates — `safe_dump_fields.rb:79` (load-bearing on its own, because the
+unauthenticated batch endpoint never runs the logic layer) and `show_receipt.rb:322-330`.
+
+**Example catalog line numbers** (`etc/examples/billing.example.yaml`, re-pinned +10 from the prep
+doc's originals): `manage_members:145` · `free_v1:192` · `identity_plus_v1:234` · commented
+`team_plus_v1:293-330` · `manage_members` inside it `:317` · `identity_plus_v1` limits
+`role_admins_per_org:268`, `role_members_per_org:269`, `total_members_per_org:273`.
+
+**#3993** is open, filed 2026-08-04, no comment activity as of 2026-08-09. All four defects stand.
+
+---
+
+## 4. Decisions waiting on you
+
+### 4.1 — where numbers go (blocks stream D, the whole content phase)
+
+The prep doc's §4.1 lays out three options and recommends **option 2 + extending assertion 4**:
+operator pages link to the surviving `self-hosting/environment-variables` and `configuration.md`
+rather than restating values, and `check-frontmatter.mjs`'s assertion 4 is re-scoped so an
+`audience: operator` page writing an ALL_CAPS variable next to a value must link to the page that
+owns it.
+
+I asked this in the remote session and the prompt returned "recommended option selected", but the
+system flagged that no human input had actually been received, so **I did not build on it.** Treat
+§4.1 as open.
+
+For what it's worth, §3's standalone-mode finding makes option 2 look stronger than when the doc was
+written: on a stock self-hosted instance the entitlement limits are infinite, so an operator page
+that states them is stating a hosted-only number on a self-hosted page — the exact error the rule
+exists to prevent.
+
+### 4.2 — where the ownership-transfer page goes
+
+New page, in no stream's scope, discovered by the re-verification pass. It is an operator action, so
+it fits Configure — but Operate is where it most naturally belongs and Operate is Phase 4. Either
+place it in Phase 3's Configure group or defer it to Phase 4 and note the reciprocal aside will point
+at `self-hosting/index` until then.
+
+### 4.3 — the production `etc/billing.yaml`
+
+Still outstanding from Phase 2. Its reach is narrower than it looks (prep doc §7 item 4), and §3
+above narrows it further for the operator tree specifically.
+
+---
+
+## 5. Stream B — reconnaissance, not the plan
+
+I gathered the following so you are not starting cold. **This is raw material; stream B's actual
+deliverable — exact line ranges per target page, leftover accounting, overlap resolution — has not
+been produced.**
+
+### `installation.md` structure (481 lines)
+
+```
+ 10  ## Deployment Options
+ 12  ### Docker Deployment
+ 70  ### Manual Installation          (Debian/Ubuntu and RHEL; systemd at 185-189)
+200  ## Reverse Proxy Configuration
+204  ### Nginx
+278  ### Caddy
+307  ### Apache
+345  ## SSL/TLS Configuration
+347  ### Let's Encrypt (Certbot)
+376  ### Custom SSL Certificates
+391  ### Redis Configuration          ← note: nested under SSL/TLS. Structural bug.
+471  ## Next Steps
+```
+
+Two things to notice. **`### Redis Configuration` at 391 is nested under `## SSL/TLS Configuration`**,
+which is wrong and is part of why the page reads as six unrelated jobs — the split is a chance to fix
+it. And **systemd has no heading of its own** (it is 185-189 inside Manual Installation), so
+`install/run-as-a-service` is closer to new writing than to moved content.
+
+### The Phase 1 correction that must survive intact
+
+Lines **244** and **253** carry `proxy_set_header X-Forwarded-For $remote_addr;`. The reasoning is at
+**266-268** — three bullets covering why the overwrite is required for the default
+`TRUSTED_PROXY_MODE=filter`, the `TRUSTED_PROXY_MODE=depth` exception, and the equivalent Caddy
+`header_up X-Forwarded-For {client_ip}` (which appears at 294 and 301). All of this lands on
+`install/reverse-proxy-and-tls` and none of it may be paraphrased in transit.
+
+### Locale copies — the split's translation cost
+
+**Seven non-EN copies, and the loss is not uniform.** The prep doc §4.2 frames this as "7 locales ×
+a 481-line page"; it is actually five near-complete translations and two stubs:
+
+| Locale | Lines |
+|---|---|
+| `mi`, `tr`, `uk`, `zh-cn` | 421 |
+| `sv` | 420 |
+| `da` | 65 |
+| `pt-br` | 36 |
+
+(EN is 481. The `self-hosting` tree exists in 17 locales; only these 7 carry `installation.md`.)
+
+### One prep-doc assumption that turns out to be false, in your favour
+
+§5 warns that `install/docker` must not inherit the inert `JOBS_SCHEDULER_ENABLED` /
+`JOBS_FALLBACK_SYNC` instruction. **`installation.md` does not currently mention either variable** —
+I grepped. The contradiction lives only in the app repo (`docker/README.md:90`,
+`docker-compose.full.yml:253`). So this is a "do not import it" constraint, not a "strip it out" one.
+
+### Frontmatter backfill — current state of all seven
+
+None carries `audience`, `pageType` or `sourceOfTruth`. All seven have only `title`, `description`,
+and a `sidebar.order`. Note the collision to resolve while you are in there: **`self-hosting/index`
+and `simple-or-full-auth` both sit at `sidebar.order: 3`**, as does `installation`
+(`environment-variables` and `upgrading-v0-23` both claim 5).
+
+---
+
+## 6. Stream C inputs
+
+`config/redirects.mjs:75-76` holds the two shims, with the comment block at `:70-74` explaining they
+exist because non-EN copies of `run-your-own-instance` carry relative `./installation` and
+`./configuration` links:
+
+```js
+{ from: "start/installation",   to: "self-hosting/installation" },
+{ from: "start/configuration",  to: "self-hosting/configuration" },
+```
+
+Retiring `self-hosting/installation` in the split makes the first one point at a redirect, and
+`assertNoChainedRedirects` fails the build. A shim cannot point at five targets, so each must
+repoint at one — probably `install/docker`, since that is where a reader following a stale
+installation link most likely wants to land, but that is stream C's call to justify.
+
+The locale-404 warning is `src/pages/en/self-hosting/configuration-generator.astro` — an `.astro`
+page, so it is outside the content collection by necessity, not by accident. Read it before choosing
+between a redirect entry, a move into the collection, and a per-locale route.
+
+---
+
+## 7. Gotchas
+
+**The subagent fan-out is broken in the remote environment, not in the work.** Every workflow agent
+hit a harness fault where the permission handler stripped required parameters from every tool call,
+so eight agents returned nothing. Stream A above was done solo as a result. This should not affect
+you locally — but if you fan out and see `The required parameter X is missing` on otherwise valid
+calls, that is the same fault and not something in your prompts.
+
+**The app repo is read-only through the session proxy.** Filing or commenting on `onetimesecret`
+issues needs it attached with push access. Relevant if the transfer-ownership REST gap or the #3993
+defects are worth commenting on.
+
+**Two published pages still carry unconfirmable claims** — `pricing/compare-plans`'s four-column
+matrix and `custom-domains/access-and-privacy` — both waiting on the catalog. Unchanged by this
+session's work.
+
+---
+
+## 8. Suggested order
+
+1. Answer §4.1. It is one line and it gates 26 pages.
+2. Stream B, then C — they need no app source and the split unblocks the `install/` group.
+3. Stream A forward — the operator ledgers, one per sub-tree, in the archived ledgers' format.
+   §3 above is the seed for the organizations/entitlements rows.
+4. Stream D, then E.
+
+The cheapest early win is the frontmatter backfill in §5 — seven pages, no research needed beyond
+choosing a `pageType`, and it makes the operator tree legible to the checkers before any new page
+lands.

--- a/docs/planning/documentation-audit-2026-08-phase-3-prep.md
+++ b/docs/planning/documentation-audit-2026-08-phase-3-prep.md
@@ -145,10 +145,16 @@ Dashboard and Workspace Branding for Team Plus.
   string "Team Plus" occurs nowhere in its `src/`, and its comparison table carries no member, invite,
   seat or organization row at all.
 - **App repo example catalog.** `etc/examples/billing.example.yaml` defines two active plans,
-  `free_v1:182` and `identity_plus_v1:224`, with the team tier present only as a commented-out block
-  (`:291-318`). `identity_plus_v1`'s entitlements do **not** include `manage_members` — the entitlement
-  exists at `:135` but appears only inside the commented team block at `:307` — and its limits are
+  `free_v1:192` and `identity_plus_v1:234`, with the team tier present only as a commented-out block
+  (`:293-330`). `identity_plus_v1`'s entitlements do **not** include `manage_members` — the entitlement
+  exists at `:145` but appears only inside the commented team block at `:317` — and its limits are
   `total_members_per_org: 1`, `role_members_per_org: 0`, `role_admins_per_org: 0`, `organizations: 1`.
+  (Line numbers re-pinned to `onetimesecret@6af1fe3` by the
+  [re-verification pass](./documentation-audit-2026-08-phase-3-reverification.md#7-correction-owed-to-the-prep-document);
+  the file gained 10 lines above every citation, so all five shifted +10 with no content change.
+  That pass also found the commented team block's own `total_members_per_org` is **5**, against the
+  published matrix's "Up to 50" and "Up to 100" — the example disagrees with the docs even where it
+  is most generous.)
 
 Two independent sources, reached by different routes, agree against both published claims. Neither
 settles it: [D3](./documentation-audit-2026-08.md#d3--billing-catalog)'s reasoning holds that an example
@@ -170,7 +176,7 @@ tail pages in §2, which were written from them rather than from fresh verificat
 
 ---
 
-## 4. Four problems Phase 3 has that Phase 2 did not
+## 4. Five problems Phase 3 has that Phase 2 did not
 
 Phase 2 was a reshape: it moved pages that existed and wrote pages nothing contradicted. Phase 3 writes
 26 pages into a tree where a competing description of the same settings is still published, and where
@@ -267,6 +273,42 @@ exception — further reason to assert reachability rather than pairing. `organi
 is a fifth candidate: it tells a self-hosted reader that ownership transfer is an operator action,
 and the operator page that documents the command does not exist in any phase's scope yet.
 
+**And the command turns out to exist.** The re-verification pass found
+`bin/ots org transfer-ownership ORG NEW_OWNER` — a 371-line operation at
+`lib/onetime/operations/org/transfer_ownership.rb` with a CLI wrapper, `--dry-run`, a `--demote-to`
+choice for the outgoing owner, and documented decisions about what it does *not* do (it does not add
+the new owner if they are not already a member, and does not remove the outgoing one). The REST
+endpoint is unbuilt and the operation's own comment says the UI already tells users to transfer
+ownership, "so the gap is real". This is a page Phase 3 should write and no stream currently owns —
+see [the pass](./documentation-audit-2026-08-phase-3-reverification.md#61-the-ownership-transfer-command-exists-and-it-is-substantial)
+for the behaviour an operator page has to state. It fits Configure or Operate, and Operate is Phase 4,
+so it needs a placement call alongside §4.1.
+
+### 4.5 On a stock self-hosted instance, the plan half of plan ∩ role is not a constraint
+
+The finding with the widest reach over the 26 pages, and the one most likely to produce a wrong
+operator page if it is missed.
+
+`with_plan_entitlements.rb:44-62` defines `STANDALONE_ENTITLEMENTS` as the *full* entitlement set,
+granted whenever billing is disabled or the plan cache is empty; `:32` adds that limits return
+`Float::INFINITY` in that mode. And billing is off unless a billing config turns it on
+(`billing_config.rb:41-53` — "Returns false if file doesn't exist or enabled is not set"), while the
+production `etc/billing.yaml` ships in neither repo. So the stock self-hosted state is: every
+entitlement granted, every limit infinite, **role is the whole answer.**
+
+Three consequences for Phase 3:
+
+1. This is **structural** to standalone mode, not a shipped default an operator tunes. An operator
+   page that presents entitlements as something the operator configures would be wrong in the
+   direction the audit exists to prevent.
+2. It narrows the billing gate over the *operator* tree specifically. Operator pages do not need the
+   catalog to say what a self-hosted operator gets, because a self-hosted operator with billing off
+   gets everything. The gate still binds every claim about hosted tiers.
+3. The hosted framing does not transfer. `organizations/roles-and-permissions` is built on "a feature
+   you are paying for can still be refused"; its operator counterpart has to invert it. Every
+   reciprocal aside in the table above crosses that boundary, so this is a per-page hazard, not a
+   one-page correction.
+
 ---
 
 ## 5. Scope
@@ -341,6 +383,13 @@ the **Plan Features** panel, billing being switchable off). Record the result as
 archived rows — confirmed, moved, or gone — rather than a new ledger; anything that moved is a
 correction to a published page, not a note.
 
+**Done — see [`…-phase-3-reverification.md`](./documentation-audit-2026-08-phase-3-reverification.md).**
+No claim on any of the six pages is wrong at HEAD. One `sourceOfTruth` range was mis-aimed and has
+been repointed (`billing/index`), §3's example-catalog line numbers have been corrected above, and
+the pass turned up two scope findings: the ownership-transfer CLI command exists and is unscoped
+(§4.4 below), and standalone mode grants every entitlement with infinite limits, which is the
+governing fact for the operator tree (§4.5).
+
 **B — Split & nav mechanics.** Splits `installation.md`; builds the `install/` and `features/` sidebar
 groups; backfills `audience: operator`; fixes the configuration-generator locale warning. Needs no app
 source — **can start now.**
@@ -363,11 +412,17 @@ catalog arrives, along with the merge of the pricing pages into `billing/index` 
 
 ## 7. What has to be true before launch
 
-1. **App source cloned** — `onetimesecret/onetimesecret`, unshallowed. Gates streams A, D, E. Its
-   first use is the re-verification pass over the six §2 tail pages (§6), not new research.
+1. ~~**App source cloned**~~ — **done.** `onetimesecret@6af1fe3` (2026-08-08), fully unshallowed,
+   157 commits past the ledgers' `aafe503` pin. Its first use was the re-verification pass over the
+   six §2 tail pages, which is [complete](./documentation-audit-2026-08-phase-3-reverification.md).
 2. **§4.1 answered** — where do numbers go while the Reference does not exist? A one-line call, and
    the thing most likely to decide whether Phase 3 output ages well. Gates stream D.
-3. **onetimesecret#3993 read** — its current state decides what three Phase 3 pages may claim (§5).
+3. ~~**onetimesecret#3993 read**~~ — **done, and nothing has moved.** Read 2026-08-09: still open,
+   filed 2026-08-04 as "Four operator-facing surfaces contradict the code", no comment activity. All
+   four defects stand as §5 assumes, so the three constrained pages are constrained exactly as
+   written. The issue's fourth defect — the DLQ consumer silently discarding non-auth templates
+   (`dlq_email_consumer_job.rb:151-155`) — is not in §5's list and belongs to Phase 4's Operate
+   group; noted so it is not lost.
 4. **The production `etc/billing.yaml` requested** — still outstanding from Phase 2. Its reach is now
    narrower than it looked: it gates `features/billing-and-entitlements` outright, the merge of the
    pricing pages into `billing/index`, the completion of `billing/managing-your-subscription`'s payment

--- a/docs/planning/documentation-audit-2026-08-phase-3-prep.md
+++ b/docs/planning/documentation-audit-2026-08-phase-3-prep.md
@@ -89,6 +89,16 @@ naming a single tier's contents. All three do exactly that and none names one. `
 
 `features/billing-and-entitlements` remains genuinely blocked — its whole subject is the catalog.
 
+**The cost of that decision, named.** Adding the two billing pages without merging the pricing pages
+puts four entries in one sidebar group (`config/sidebar.mjs:262-267`: How plans work · Managing your
+subscription · Plans and pricing · Compare plans), and the first and third cover adjacent ground.
+`billing/index` describes the mechanism — a plan belongs to an organization, **Plan Features** is
+authoritative, role gates the rest — while `pricing/index` lists tier contents, which is the half the
+catalog gates. A reader looking for "what do I get" can reasonably land on either. That is the honest
+state rather than an oversight: the alternative was withholding the mechanism until the catalog
+arrives, and the mechanism is what the rest of the end-user tree needs to link to. It resolves when
+the merge happens, which is the same held-out sixth stream (§6) — not a separate cleanup.
+
 **One dangling reference is now closed.** `organizations/audit-trail` had shipped leaning on the
 plan ∩ role rule with no page to link to; a reader hitting "your plan includes this but your role
 refuses it" had nowhere to go. `organizations/roles-and-permissions` is that page.
@@ -102,7 +112,8 @@ before commit rather than corrected. Both wait on the catalog.
 plan ∩ role formula with `file:line` evidence, and its "do not claim" list is what kept the tier
 contents out. That is the ledgers earning their archive. It also means these six inherit the ledgers'
 staleness: they were verified against `onetimesecret@aafe503` in August 2026, and stream A should
-re-verify the rows these pages rest on rather than treating them as settled.
+re-verify the rows these pages rest on rather than treating them as settled. That pass is scoped in
+§6 as A's first work, ahead of its own research.
 
 ---
 
@@ -317,6 +328,19 @@ default or a behaviour that is not in a ledger. Every value it records must be l
 **self-hosted shipped default** unless a code path makes it structural — the distinction Phase 2's
 ledgers drew, and the one that keeps hosted claims out of operator pages.
 
+**A also owes one backward-looking pass.** The six §2 tail pages were written from the Phase 2 ledgers
+rather than from fresh reads, so they carry those ledgers' pin to `onetimesecret@aafe503`. Once the app
+source is cloned, re-verify the rows they rest on against `HEAD` before the phase's own research
+starts — it is the cheapest moment to do it, the clone is already in hand, and a drifted row propagates
+into the operator pages that link to these. Concretely, from
+[`ledger/vocabulary-and-orgs.md`](../archive/documentation-audit-2026-08-phase-2/ledger/vocabulary-and-orgs.md)
+§9 and §10: the three role templates and what each may change, the plan ∩ role formula,
+domain-scoped memberships, the member limit as a mechanism, the owner-cannot-be-demoted invariants,
+the endpoint limits, and the three `sourceOfTruth` citations on `billing/index` (entitlement grant,
+the **Plan Features** panel, billing being switchable off). Record the result as a diff against the
+archived rows — confirmed, moved, or gone — rather than a new ledger; anything that moved is a
+correction to a published page, not a note.
+
 **B — Split & nav mechanics.** Splits `installation.md`; builds the `install/` and `features/` sidebar
 groups; backfills `audience: operator`; fixes the configuration-generator locale warning. Needs no app
 source — **can start now.**
@@ -339,7 +363,8 @@ catalog arrives, along with the merge of the pricing pages into `billing/index` 
 
 ## 7. What has to be true before launch
 
-1. **App source cloned** — `onetimesecret/onetimesecret`, unshallowed. Gates streams A, D, E.
+1. **App source cloned** — `onetimesecret/onetimesecret`, unshallowed. Gates streams A, D, E. Its
+   first use is the re-verification pass over the six §2 tail pages (§6), not new research.
 2. **§4.1 answered** — where do numbers go while the Reference does not exist? A one-line call, and
    the thing most likely to decide whether Phase 3 output ages well. Gates stream D.
 3. **onetimesecret#3993 read** — its current state decides what three Phase 3 pages may claim (§5).

--- a/docs/planning/documentation-audit-2026-08-phase-3-reverification.md
+++ b/docs/planning/documentation-audit-2026-08-phase-3-reverification.md
@@ -1,0 +1,258 @@
+# Phase 3 stream A — re-verification of the six tail pages
+
+**What this is:** the backward-looking pass
+[`documentation-audit-2026-08-phase-3-prep.md`](./documentation-audit-2026-08-phase-3-prep.md) §6
+assigns to stream A as its first work, ahead of its own research.
+
+The six pages written after Phase 2 closed were built from the Phase 2 ledgers rather than from fresh
+reads, so they inherit those ledgers' pin to app commit `aafe503`. This re-checks the rows they rest
+on against app `HEAD`.
+
+It is a **diff against the archived rows**, not a new ledger. Rows that hold are recorded as holding
+so nobody re-does the work; rows that moved are corrections to published pages.
+
+| | |
+|---|---|
+| Ledger pin | `onetimesecret@aafe503` (`fix(workspace): keep recipient field in generate-password mode (#4010)`) |
+| Verified against | `onetimesecret@6af1fe3`, 2026-08-08 |
+| Distance | **157 commits** |
+| Verified on | 2026-08-09, full unshallowed clone |
+
+**Verdicts used:** `confirmed` (true at HEAD, same `file:line`) · `moved` (true, different `file:line`)
+· `changed` (no longer accurate) · `gone` · `unverifiable`.
+
+**Headline: no claim on any of the six pages is wrong.** Every behavioural row holds at HEAD. The
+corrections below are citation-level — one mis-aimed `sourceOfTruth` range, and a planning document
+whose line numbers have drifted — plus two findings that expand Phase 3's scope rather than contradict
+it.
+
+---
+
+## 1. Drift survey
+
+The mechanical question first: of the files the six pages cite, which changed at all between
+`aafe503` and `HEAD`?
+
+| File | Changed? |
+|---|---|
+| `lib/onetime/models/organization_membership.rb` | unchanged |
+| `lib/onetime/models/organization.rb` | unchanged |
+| `lib/onetime/models/organization/features/with_plan_entitlements.rb` | unchanged |
+| `lib/onetime/models/organization_membership/features/with_materialized_entitlements.rb` | unchanged |
+| `lib/onetime/operations/org/transfer_ownership.rb` | unchanged |
+| `apps/api/organizations/logic/members/*` | unchanged |
+| `lib/onetime/models/receipt.rb` | unchanged |
+| `lib/onetime/models/receipt/features/safe_dump_fields.rb` | unchanged |
+| `apps/api/v2/logic/secrets/show_receipt.rb` | unchanged |
+| `src/shared/composables/useEntitlements.ts` | unchanged |
+| `locales/content/en/workspace-billing.json` | **+18 lines** |
+| `etc/examples/billing.example.yaml` | **+10 lines** |
+
+Only two moved, and neither moved for a reason that touches a documented claim — the locale file
+gained yearly-billing-interval and currency-migration-refund strings, the example catalog gained
+`automatic_tax` and `payment_method_configuration` keys. Both insertions land *above* every line the
+docs cite, which is why the effect is pure line-number shift.
+
+---
+
+## 2. `organizations/roles-and-permissions`
+
+| Claim | Archived evidence | HEAD evidence | Verdict |
+|---|---|---|---|
+| Three roles, nesting owner ⊃ admin ⊃ member | `organization_membership.rb:72-106` | same — `MEMBER_ENTITLEMENTS:72`, `ADMIN_ENTITLEMENTS:79`, `ROLE_ENTITLEMENTS:102-106` composing them with `\|` | confirmed |
+| Effective permission = plan ∩ role | `with_materialized_entitlements.rb:13-18` | same, verbatim: `membership.entitlements = org.materialized_entitlements ∩ ROLE_ENTITLEMENTS[role]` | confirmed |
+| Role-change screen accepts **member** and **admin** only | `update_member_role.rb:29,154-192` | same — `VALID_ROLES = %w[member admin]` at `:29`, enforced `:154-162` | confirmed |
+| You cannot change an owner's role there | `update_member_role.rb:154-192` | `:163-171`, `cannot_change_owner_role` | confirmed |
+| You cannot promote to owner there | `update_member_role.rb:154-192` | `:188-194`, `cannot_promote_to_owner` | confirmed |
+| An owner cannot be removed at all | not separately cited | `remove_member.rb:161-166`, `cannot_remove_owner` — unconditional | confirmed, **with an operator caveat, see §6.2** |
+| Nobody can remove themselves through the member list | not separately cited | `remove_member.rb:169-175`, `cannot_remove_self` | confirmed |
+| The last owner cannot be demoted | not separately cited | `set_role.rb:42-43` → `support.rb:20-24` `sole_owner?` | confirmed |
+| A domain-scoped membership is barred from member management whatever its role | not separately cited | `update_member_role.rb:49-50` and `remove_member.rb:48-49`, both `domain_scoped_forbidden`, checked before any role logic | confirmed |
+
+All three `sourceOfTruth` ranges in this page's frontmatter resolve at HEAD and support what they are
+attached to. **No correction needed.**
+
+Worth recording for the operator pages: the domain-scope refusal is evaluated *before* the role
+check in both endpoints, so it is structural rather than a role consequence. The page's "whatever
+their role otherwise" is exactly right.
+
+---
+
+## 3. `organizations/ownership-and-transfer`
+
+| Claim | HEAD evidence | Verdict |
+|---|---|---|
+| The owner cannot be demoted from inside the app | `set_role.rb:42-43`, sole-owner refusal; `update_member_role.rb:163-171` for the in-app path | confirmed |
+| The owner cannot be removed from inside the app | `remove_member.rb:161-166` | confirmed |
+| Nobody can be promoted to owner from inside the app | `update_member_role.rb:188-194` | confirmed |
+| Ownership transfer is an operator action; contact support | see §6.1 — **the operator action now has a documented command** | confirmed, but understated |
+
+---
+
+## 4. `billing/index`
+
+| Citation as published | Verdict |
+|---|---|
+| `with_plan_entitlements.rb:48-56` — *"the plan grants capabilities to the organization"* | **mis-cited** — see below |
+| `useEntitlements.ts:16-44` + `locales/content/en/workspace-billing.json` — *"the in-app panel is titled Plan Features"* | confirmed |
+| `with_entitlements.rb:149-153` — *"billing can be switched off entirely, which is the self-hosted default"* | confirmed |
+
+**The mis-citation.** `with_plan_entitlements.rb:48-56` is stable — the file is byte-identical since
+`aafe503` and line 48 is `STANDALONE_ENTITLEMENTS` at both commits. But that constant is the
+*standalone-mode full-access set*, not the plan-grant mechanism the page attaches it to. The line
+range is right about nothing having moved and wrong about what lives there.
+
+The claim's real evidence is the resolution order at `with_plan_entitlements.rb:181-212`, whose own
+comment enumerates it: billing disabled → `STANDALONE_ENTITLEMENTS` (`:181`, `:200`); no planid →
+`FREE_TIER_ENTITLEMENTS` (`:183`, `:212`). **Action: repoint the first `sourceOfTruth` clause to
+`:181-212`.** The page's prose is correct as written; only the citation needs moving.
+
+**"Plan Features" confirmed and unmoved.** The string is at `workspace-billing.json:59`, and both
+hunks of the +18-line diff land at `:396` and `:1037` — far below it. `useEntitlements.ts:16-44` is
+the entitlement→label map that populates the panel and is unchanged. The pairing is correct: the map
+supplies the rows, the locale file supplies the title.
+
+**"Billing off is the self-hosted default" confirmed, and it is a shipped default, not structural.**
+`with_entitlements.rb:149-153` is `billing_enabled?` delegating to
+`Onetime::BillingConfig.instance.enabled?`. The default lives one layer down at
+`billing_config.rb:41-53`, whose contract is documented in its own comment: *"Returns false if file
+doesn't exist or enabled is not set."* Since the production `etc/billing.yaml` ships in neither repo,
+a stock self-hosted instance has no billing config and billing is therefore off. `BILLING_ENABLED`
+overrides it, and any value other than `true/1/false/0` raises `Onetime::ConfigError` rather than
+silently disabling — a detail an operator page will need and no page currently states.
+
+---
+
+## 5. `share/receiving-secrets`
+
+The security-relevant page. All three citations resolve **exactly** at the published line numbers,
+and all three files are unchanged since `aafe503`.
+
+| Citation as published | HEAD | Verdict |
+|---|---|---|
+| `receipt.rb:93-101` — `SOURCE_CAPABILITIES`, incoming ⇒ `shows_share_link: false` | `:93-96` the map, `:98-101` `WITHHELD_CAPABILITIES` | confirmed |
+| `safe_dump_fields.rb:66-67,79` | `:66-67` `custid`/`owner_id`, `:79` `secret_identifier` | confirmed |
+| `show_receipt.rb:322-330` | `share_path`/`share_url` gated on `link_visible` | confirmed |
+
+The claim is not only true but **defended in depth**, which strengthens rather than qualifies it:
+
+- The default is withholding, not showing — `WITHHELD_CAPABILITIES` catches any unrecognised
+  `source` value (`receipt.rb:98-101`), so a typo or an unshipped future source fails closed.
+- The `safe_dump` gate at `:79` is load-bearing independently of the logic layer. Its own comment
+  says why: the unauthenticated batch endpoint `V3::Logic::Secrets::ShowMultipleReceipts` serializes
+  via `safe_dump` and *never runs the logic-layer gate*.
+
+**No correction needed.** If anything the page undersells the guarantee.
+
+---
+
+## 6. Two findings that change Phase 3's scope
+
+### 6.1 The ownership-transfer command exists, and it is substantial
+
+The prep doc (§4.4) records `organizations/ownership-and-transfer` as a reciprocal-aside candidate
+whose operator counterpart "does not exist in any phase's scope yet," on the understanding that the
+transfer is a support-mediated action.
+
+It is a shipped CLI command: **`bin/ots org transfer-ownership ORG NEW_OWNER`**, implemented in a
+371-line operation at `lib/onetime/operations/org/transfer_ownership.rb` with a CLI wrapper at
+`lib/onetime/cli/org/transfer_ownership_command.rb`.
+
+The operation's own header documents behaviour an operator page would have to state, and which
+nothing in the docs currently does:
+
+- `--demote-to` chooses the outgoing owner's new role, from
+  `SetRole::VALID_ROLES - ['owner']` (`:111-116`) — deliberately sourced from `SetRole` rather than
+  forked, so the two cannot drift.
+- The new owner is **not** auto-added if they are not already an active member (decision D28) —
+  the operator must create the membership first.
+- The outgoing owner is **not** removed (decision D27); `--demote-to` has no `remove` value.
+- The operation is idempotent and demotes **all** other active owners, so a partially-applied
+  transfer can be re-run.
+- It promotes first and demotes second, because demote-first would trip the sole-owner guard
+  (`:36-40`) — the org has a live owner at every instant.
+- There is a `--dry-run` (`:137`).
+- A transfer transiently fails `bin/ots org doctor` mid-flight (`:43-46`).
+
+The app's own comment at `:19-24` notes the REST endpoint is unbuilt (`(future) POST
+/api/colonel/organizations/:org_id/transfer-ownership`) and that the UI "already tells end users to
+transfer ownership, so the gap is real."
+
+**Consequences.**
+
+1. `organizations/ownership-and-transfer`'s "what to send support" is correct for hosted readers but
+   incomplete for self-hosted ones, who can run the command themselves.
+2. Phase 3 gains a page that is in no stream's scope. It fits the Configure or an Operate group;
+   Operate is Phase 4, so this needs a placement call.
+3. It is a clean reciprocal-aside pair, adding a fifth to §4.4's "nine plus four."
+
+### 6.2 Standalone mode grants every entitlement — including `manage_members`
+
+`with_plan_entitlements.rb:44-47,48-62`: `STANDALONE_ENTITLEMENTS` is the full set, and its comment
+states the design — *"When billing is disabled or plan cache is empty, users get full access"*, and
+it must include everything in `ROLE_ENTITLEMENTS` (ADR-012) *"so the membership intersection (org ∩
+role) doesn't exclude member-level ones."* `:32` adds that limits return `Float::INFINITY` in this
+mode.
+
+Combined with §4 — billing off is the stock self-hosted state — this is the single most important
+fact for the operator tree, and no page states it:
+
+> On a self-hosted instance with no billing configured, the plan half of plan ∩ role is not a
+> constraint. Every entitlement is granted to the organization and every limit is infinite, so a
+> member's effective permissions are decided by their role alone.
+
+**Consequences.**
+
+1. It is a **structural** behaviour of standalone mode, not a shipped default an operator tunes.
+   Getting this backwards on an operator page is precisely the error the audit exists to prevent.
+2. It narrows the billing gate's reach for the operator tree specifically. Phase 3's operator pages
+   do not need the catalog to state what a self-hosted operator gets, because a self-hosted operator
+   with billing off gets everything. The gate still binds anything about *hosted* tiers.
+3. `roles-and-permissions`'s framing — "a feature you are paying for can still be refused" — is a
+   hosted framing. Its operator counterpart has to invert it: on a stock self-hosted instance the
+   plan never refuses anything, and role is the whole answer.
+
+---
+
+## 7. Correction owed to the prep document
+
+§3 of the prep doc cites `etc/examples/billing.example.yaml` by line number, recorded at `aafe503`.
+The file gained 10 lines at `:51-60`, so **every citation below the insertion has shifted by exactly
++10**. Content is unchanged in all cases — verdict `moved`, not `changed`.
+
+| Cited as | Correct at HEAD |
+|---|---|
+| `manage_members` entitlement defined at `:135` | `:145` |
+| `free_v1` at `:182` | `:192` |
+| `identity_plus_v1` at `:224` | `:234` |
+| commented team block at `:291-318` | `:293-330` (`team_plus_v1` at `:293`) |
+| `manage_members` inside the team block at `:307` | `:317` |
+
+The substance of the billing finding is **unaffected and still holds**: the two active plans are
+still exactly `free_v1` and `identity_plus_v1`, the team block is still commented out, and
+`identity_plus_v1`'s limits are still `total_members_per_org: 1` (`:273`), `role_admins_per_org: 0`
+(`:268`), `role_members_per_org: 0` (`:269`).
+
+One detail sharpens the finding rather than changing it: the commented team block's own
+`total_members_per_org` is **5** (`:325`), against the published matrix's "Up to 50" and "Up to 100".
+The example file disagrees with the docs even where it is most generous. This is still an example
+file and still cannot arbitrate what buyers are sold — [D3](./documentation-audit-2026-08.md#d3--billing-catalog)
+holds unchanged.
+
+---
+
+## 8. What this pass did not cover
+
+Stated so the gap is visible rather than assumed closed:
+
+- **`billing/managing-your-subscription`** — not re-verified. Its subject is the hosted subscription
+  surface, which the billing gate already holds open, and the two facts it turns on (owner-only,
+  plan change applies to everyone) are corollaries of rows confirmed in §2.
+- **`contribute/developer-on-ramp`** — not re-verified. Its claims are about the *docs* repo, which
+  is not pinned to `aafe503`, so the staleness this pass exists to check does not apply. Its owed
+  app-repo half is now unblocked (the clone is on disk) but is writing work, not verification.
+  Its "32 ADRs" figure is unchecked and should be counted, not repeated.
+- **`organizations/roles-and-permissions`'s member-limit rows** — the enforcement path is confirmed
+  (`total_members_per_org` and the per-role caps exist and are read), but the *values* were not
+  re-derived, because on a self-hosted instance §6.2 makes them infinite and on hosted they are
+  catalog-gated. The page states the limit as a mechanism and no number, which remains correct.

--- a/src/content/docs/en/billing/index.md
+++ b/src/content/docs/en/billing/index.md
@@ -3,7 +3,7 @@ title: How plans work
 description: A plan belongs to your organization rather than your account, what it includes is shown in the app under Plan Features, and your role decides how much of it reaches you.
 audience: end-user
 pageType: concept
-sourceOfTruth: onetimesecret/lib/onetime/models/organization/features/with_plan_entitlements.rb:48-56 (the plan grants capabilities to the organization); onetimesecret/src/shared/composables/useEntitlements.ts:16-44 and onetimesecret/locales/content/en/workspace-billing.json (the in-app panel is titled "Plan Features"); onetimesecret/lib/onetime/models/features/with_entitlements.rb:149-153 (billing can be switched off entirely, which is the self-hosted default)
+sourceOfTruth: onetimesecret/lib/onetime/models/organization/features/with_plan_entitlements.rb:181-212 (the plan grants capabilities to the organization — the entitlement resolution order); onetimesecret/src/shared/composables/useEntitlements.ts:16-44 and onetimesecret/locales/content/en/workspace-billing.json:59 (the in-app panel is titled "Plan Features"); onetimesecret/lib/onetime/models/features/with_entitlements.rb:149-153 and onetimesecret/lib/onetime/billing_config.rb:41-53 (billing can be switched off entirely, and is off unless a billing config sets it, which is the self-hosted default)
 ---
 
 :::note


### PR DESCRIPTION
## What changed

Two things the six-page Phase 2 tail left implicit in the Phase 3 prep assessment
(`docs/planning/documentation-audit-2026-08-phase-3-prep.md`). Planning document only — no
page content, sidebar, redirect or checker changes.

**Stream A owes a backward-looking pass.** The six tail pages were written from the Phase 2
ledgers rather than from fresh reads, so they inherit those ledgers' pin to
`onetimesecret@aafe503`. §2 already said stream A "should re-verify"; §6 now scopes it as A's
first work, ahead of its own research — naming the specific rows (the three role templates and
what each may change, the plan ∩ role formula, domain-scoped memberships, the member limit,
the owner-cannot-be-demoted invariants, the endpoint limits, and `billing/index`'s three
`sourceOfTruth` citations), and asking for the result as a diff against the archived rows
rather than as a new ledger. §7's launch condition 1 points at it, so the clone's first use is
fixed rather than left to whoever starts.

**The billing/pricing adjacency is recorded as an accepted cost.** Publishing the two billing
pages without merging the pricing pages puts four entries in one sidebar group
(`config/sidebar.mjs:262-267`), and How plans work / Plans and pricing cover adjacent ground —
one describes the mechanism, the other lists tier contents. §2 now states that plainly, with
the reason (the alternative was withholding the mechanism the rest of the end-user tree links
to) and the resolution (the held-out merge stream in §6, not a separate cleanup).

## Page taxonomy

- [x] N/A — this change introduces no new decision the reader has to make.

Planning document under `docs/planning/`, not a published page; no decision axis, flag, tier,
entitlement, region or config choice is introduced.

## Checklist

- [x] Internal links resolve within the current locale (no 404s) — the one new link is
  repo-relative to the archived `ledger/vocabulary-and-orgs.md`, matching the existing links in
  this file
- [x] New pages were copied from a template and match its type's job — N/A, no new pages
- [x] Sidebar and translation keys updated if navigation changed — N/A, navigation unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVxdR8BpP5XsiqGVKdf5he)_